### PR TITLE
Prevent ArrayNode's tryFind from returning Some null when looking for a ...

### DIFF
--- a/src/FSharpx.Collections/PersistentHashMap.fs
+++ b/src/FSharpx.Collections/PersistentHashMap.fs
@@ -282,7 +282,7 @@ and private ArrayNode(thread,count',array':INode[]) =
                 let idx = mask(hash, shift)
                 let node = this.array.[idx]
                 if node = Unchecked.defaultof<INode> then None else
-                Some(node.find(shift + 5, hash, key))
+                node.tryFind(shift + 5, hash, key)
 
             member this.without(shift, hashKey, key) =
                 let idx = mask(hashKey, shift)


### PR DESCRIPTION
...non-existent key.