### PR TITLE
Block resize array basic implementation

### DIFF
--- a/src/FSharpx.Collections.Experimental/BinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/BinomialHeap.fs
@@ -221,6 +221,7 @@ type BinomialHeap<'T when 'T : comparison> (isDescending : bool, heap : list<Bin
         member this.Insert element = this.Insert element :> IPriorityQueue<'T>
         member this.TryPeek() = this.TryGetHead()
         member this.Peek() = this.Head()
+        member this.Length = this.Length()
 
         member this.TryPop() = 
             match this.TryUncons() with

--- a/src/FSharpx.Collections.Experimental/BlockResizeArray.fs
+++ b/src/FSharpx.Collections.Experimental/BlockResizeArray.fs
@@ -1,0 +1,46 @@
+﻿namespace FSharpx.Collections
+
+// Resize array fith fixed size block memory allocation.
+// Provide more optimal space usage for huge arrays than standard ResizeArray.
+// Basic version created by Avdyukhin Dmitry <dimonbv@gmail.com>
+
+type BlockResizeArray<'T> () =
+    let initArraysCount = 1
+    let mutable count = 0
+    let shift = 17
+    let blockSize = 1 <<< shift
+    let smallPart = blockSize - 1
+    let mutable arrays =    Array.init initArraysCount (fun _ -> Array.zeroCreate blockSize)
+    let mutable cap = blockSize * arrays.Length
+    let mutable nextAllocate = cap
+    member this.Add (x : 'T) =
+        if count = nextAllocate then
+            if count = cap then
+                let oldArrays = arrays
+                arrays <- Array.zeroCreate (arrays.Length * 2)
+                for i = 0 to oldArrays.Length-1 do
+                    arrays.[i] <- oldArrays.[i]
+                cap <- blockSize * arrays.Length
+            arrays.[count >>> shift] <- Array.zeroCreate blockSize
+            nextAllocate <- nextAllocate + blockSize
+        arrays.[count >>> shift].[count &&& smallPart] <- x
+        count <- count + 1
+
+    member this.Item i =
+        arrays.[i >>> shift].[i &&& smallPart]
+
+    member this.Set i value =
+        arrays.[i >>> shift].[i &&& smallPart] <- value
+
+    member this.DeleteBlock i = arrays.[i] <- null
+    member this.Count = count
+    member this.Shift = shift
+
+    member this.ToArray() =
+        let res = Array.zeroCreate count
+        for i = 0 to (count >>> shift) - 1 do
+            Array.blit arrays.[i] 0 res (i <<< shift) blockSize
+        if (count &&& smallPart) <> 0 then
+            let i = count >>> shift
+            Array.blit arrays.[i] 0 res (i <<< shift) (count &&& smallPart)
+        res

--- a/src/FSharpx.Collections.Experimental/FSharpx.Collections.Experimental.fsproj
+++ b/src/FSharpx.Collections.Experimental/FSharpx.Collections.Experimental.fsproj
@@ -158,6 +158,7 @@
     <Compile Include="SkewBinaryRandomAccessList.fs" />
     <Compile Include="TimeSeries.fs" />
     <Compile Include="CSharpCompat.fs" />
+    <Compile Include="BlockResizeArray.fs" />
     <None Include="paket.template" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FSharpx.Collections.Experimental/PairingHeap.fs
+++ b/src/FSharpx.Collections.Experimental/PairingHeap.fs
@@ -210,6 +210,7 @@ type PairingHeap<'T when 'T : comparison> =
         member this.Insert element = this.Insert element :> IPriorityQueue<'T>
         member this.TryPeek() = this.TryGetHead()
         member this.Peek() = this.Head()
+        member this.Length = this.Length()
 
         member this.TryPop() = 
             match this.TryUncons() with

--- a/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
@@ -1,4 +1,4 @@
-﻿module FSharpx.Collections.Tests.BlockResizeArrayTest
+﻿module FSharpx.Collections.Experimental.Tests.BlockResizeArrayTest
 
 open FSharpx.Collections
 open NUnit.Framework
@@ -30,7 +30,7 @@ let ``random access performance`` () =
     for i in 0..arraySize do bra.Add x
     let b = ref 0UL
     averageTime testIters "ResizeArray random access" (fun () -> for i in access do ra.[i] <- 0UL) 
-    averageTime testIters "Array seqrandom access" (fun () -> for i in access do a.[i] <- 0UL)       
+    averageTime testIters "Array random access" (fun () -> for i in access do a.[i] <- 0UL)       
     averageTime testIters "BlockResizeArray random access" (fun () -> for i in access do bra.Set i 0UL)
 
 [<Test>]

--- a/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
@@ -34,7 +34,7 @@ let ``random access performance`` () =
     averageTime testIters "BlockResizeArray random access" (fun () -> for i in access do bra.Set i 0UL)
 
 [<Test>]
-let ``seqential access performance`` () =
+let ``sequential access performance`` () =
     let rand = System.Random()
     let access = [|0..arraySize-1|]
     let a = Array.init arraySize  (fun _ -> x)

--- a/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
@@ -1,0 +1,48 @@
+﻿module FSharpx.Collections.Tests.BlockResizeArrayTest
+
+open FSharpx.Collections
+open NUnit.Framework
+open FsUnit
+open FSharpx.Collections.TimeMeasurement
+
+let arraySize = 2048*2048*10
+let testIters = 10
+let x = 1000UL
+
+[<Test>]
+let ``allocation performance`` () =
+    
+    averageTime testIters "ResizeArrayAlloc" (fun () -> 
+        let a = new ResizeArray<uint64>()
+        for i in 0..arraySize do a.Add x )    
+    averageTime testIters "BlockResizeArrayAlloc" (fun () -> 
+        let a = new BlockResizeArray<uint64>()
+        for i in 0..arraySize do a.Add x )  
+
+[<Test>]
+let ``random access performance`` () =
+    let rand = System.Random()
+    let access = [|for i in 0..arraySize-1 -> rand.Next(0, arraySize - 1)|]
+    let a = Array.init arraySize  (fun _ -> x)
+    let ra = new ResizeArray<uint64>()
+    for i in 0..arraySize do ra.Add x
+    let bra = new BlockResizeArray<uint64>()
+    for i in 0..arraySize do bra.Add x
+    let b = ref 0UL
+    averageTime testIters "ResizeArray random access" (fun () -> for i in access do ra.[i] <- 0UL) 
+    averageTime testIters "Array seqrandom access" (fun () -> for i in access do a.[i] <- 0UL)       
+    averageTime testIters "BlockResizeArray random access" (fun () -> for i in access do bra.Set i 0UL)
+
+[<Test>]
+let ``seqential access performance`` () =
+    let rand = System.Random()
+    let access = [|0..arraySize-1|]
+    let a = Array.init arraySize  (fun _ -> x)
+    let ra = new ResizeArray<uint64>()
+    for i in 0..arraySize do ra.Add x
+    let bra = new BlockResizeArray<uint64>()
+    for i in 0..arraySize do bra.Add x
+    let b = ref 0UL
+    averageTime testIters "ResizeArray sequential access" (fun () -> for i in access do ra.[i] <- 0UL)    
+    averageTime testIters "Array sequential access" (fun () -> for i in access do a.[i] <- 0UL)    
+    averageTime testIters "BlockResize sequential access" (fun () -> for i in access do bra.Set i 0UL)

--- a/tests/FSharpx.Collections.Experimental.Tests/FSharpx.Collections.Experimental.Tests.fsproj
+++ b/tests/FSharpx.Collections.Experimental.Tests/FSharpx.Collections.Experimental.Tests.fsproj
@@ -104,6 +104,7 @@
     <Compile Include="RealTimeQueueTest.fs" />
     <Compile Include="RoseTreeTest.fs" />
     <Compile Include="TimeSeriesTest.fs" />
+    <Compile Include="BlockResizeArrayTest.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FSharpx.Collections.Experimental\FSharpx.Collections.Experimental.fsproj">


### PR DESCRIPTION
Basic implementation of BlockResizeArray. Main goal is more efficient space usage for huge arrays than in standard ResizeArray.

Performance tests. Random access is slower, sequential access and memory allocation (growing from "zero" to 320Mb = 10 * 2^22 * (sizeof uint64) ) faster than for ResizeArray.

```
***** allocation performance
 [fsi:ResizeArrayAlloc 643.8ms]

 [fsi:BlockResizeArrayAlloc 382.8ms]

***** random access performance
 [fsi:ResizeArray random access 766.8ms]

 [fsi:BlockResizeArray random access 1151.1ms]

***** sequential access performance
 [fsi:ResizeArray sequential access 191.5ms]

 [fsi:BlockResize sequential access 149.6ms]

```