### PR TITLE
SkewBinomialHeap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
-language: objective-c
+language: csharp
 
-env:
-  matrix:
-    - MONO_VERSION="3.8.0"
-
-install:
-  - wget "http://download.mono-project.com/archive/${MONO_VERSION}/macos-10-x86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg"
-  - sudo installer -pkg "MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg" -target /
+sudo: false  # use the new container-based Travis infrastructure 
 
 script: 
-  - ./build.sh
+  - ./build.sh All

--- a/src/FSharpx.Collections.Experimental/BinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/BinomialHeap.fs
@@ -263,8 +263,6 @@ module BinomialHeap =
     ///O(log n). Returns heap option from merging two heaps.
     let inline tryMerge (xs: BinomialHeap<'T>) (ys: BinomialHeap<'T>) = xs.TryMerge ys
 
-    //FIX
-    //Can't be O(log n) It should be at least O(n). All the n elements of the sequence have to be inserted. I think it is O(n * log n)
     ///O(n * log n). Returns heap from the sequence.
     let ofSeq descending s = BinomialHeap.ofSeq descending s
 

--- a/src/FSharpx.Collections.Experimental/BinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/BinomialHeap.fs
@@ -263,7 +263,9 @@ module BinomialHeap =
     ///O(log n). Returns heap option from merging two heaps.
     let inline tryMerge (xs: BinomialHeap<'T>) (ys: BinomialHeap<'T>) = xs.TryMerge ys
 
-    ///O(log n). Returns heap from the sequence.
+    //FIX
+    //Can't be O(log n) It should be at least O(n). All the n elements of the sequence have to be inserted. I think it is O(n * log n)
+    ///O(n * log n). Returns heap from the sequence.
     let ofSeq descending s = BinomialHeap.ofSeq descending s
 
     ///O(log n). Returns a new heap of the elements trailing the head.

--- a/src/FSharpx.Collections.Experimental/FSharpx.Collections.Experimental.fsproj
+++ b/src/FSharpx.Collections.Experimental/FSharpx.Collections.Experimental.fsproj
@@ -94,6 +94,7 @@
     <Compile Include="TimeSeries.fs" />
     <Compile Include="CSharpCompat.fs" />
     <Compile Include="BlockResizeArray.fs" />
+    <Compile Include="SkewBinomialHeap.fs" />
     <None Include="paket.template" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -116,8 +116,8 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
                 hash
             else
                 let h, t = SBHTreeRoot.uncons descending roots
-                hashIt (n - 1) (hash * 397 ^^^ Operators.hash h) t
-        hashIt (min hashElements count) 0 roots)
+                hashIt (n - 1) (~~~(hash * 397) ^^^ Operators.hash h) t
+        hashIt (min hashElements count) (hash count) roots)
         
     new() = SkewBinomialHeap(0, false, [])
 

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -1,0 +1,270 @@
+﻿namespace FSharpx.Collections.Experimental
+
+//TODO: This should be better documented
+
+open FSharpx.Collections
+open System.Collections.Generic
+
+exception Empty of string //TODO: improve this and include in the exceptions or use the Empty that is already there
+exception IncompatibleMerge of string
+
+type private 'T SBHTree = Node of 'T * 'T list * 'T SBHTree list
+
+type private 'T SBHTreeRoot = Root of int * 'T SBHTree
+
+[<AutoOpen>]
+module private Helper =
+    let inline xor a b = (a && not b) || (not a && b)
+
+module private SBHTree =
+    let item (Node (x, _, _)) = x
+
+    let link descending (Node (x, auxX, childrenX) as treeX) (Node (y, auxY, childrenY) as treeY) =
+        if xor (x <= y) descending
+            then Node (x, auxX, treeY::childrenX)
+            else Node (y, auxY, treeX::childrenY)
+
+    let skewLink descending v treeX treeY =
+        let (Node (w, aux, children)) = link descending treeX treeY
+        if xor (v <= w) descending
+            then Node (v, w::aux, children)
+            else Node (w, v::aux, children)
+
+module private SBHTreeRoot =
+    open SBHTree
+
+    let inline getTree (Root (_, tree)) = tree
+
+    let insert descending value = function
+        | Root(rank1, tree1)::Root(rank2, tree2)::roots when rank1 = rank2 -> Root(rank1 + 1, skewLink descending value tree1 tree2)::roots
+        | roots                                                            -> Root(0, Node (value, [], []))::roots
+
+    let rec insRoot descending (Root(rank, tree) as root) roots =
+        match roots with
+        | []                                  -> [root]
+        | Root(rank', _)::_ when rank < rank' -> root::roots
+        | Root(_, tree')::roots'              -> insRoot descending (Root(rank + 1, link descending tree tree')) roots'
+
+    let rec mergeRoots descending roots1 roots2 =
+        match roots1, roots2 with
+        | roots, [] | [], roots-> roots
+        | Root(rankX, treeX)::roots1', Root(rankY, _)::_ when rankX < rankY -> Root(rankX, treeX)::mergeRoots descending roots1' roots2
+        | Root(rankX, _)::_, Root(rankY, treeY)::roots2' when rankX > rankY -> Root(rankY, treeY)::mergeRoots descending roots1 roots2'
+        | Root(rank, treeX)::roots1', Root(_, treeY)::roots2'               -> insRoot descending (Root(rank + 1, link descending treeX treeY)) (mergeRoots descending roots1' roots2')
+
+    let normalize descending = function
+        | [] -> []
+        | root::roots -> insRoot descending root roots
+
+    let rec extractMinRoot descending = function
+        | [p] -> (p, [])
+        | (Root(_, tree) as root)::roots ->
+            let (Root(_, tree') as root', roots') = extractMinRoot descending roots
+            if xor (SBHTree.item tree <= SBHTree.item tree') descending
+                then root, roots
+                else root', root::roots'
+        | [] -> failwith "This should never happen"
+        
+    let rec findMinRootItem descending = function
+        | [Root(_, node)]                       -> item node
+        | Root(_, node)::roots'                 -> 
+            let this = item node
+            let other = findMinRootItem descending roots'
+            if xor (this <= other) descending
+                then this
+                else other
+        | []                                    -> failwith "This should never happen"
+
+    let rec toListOrdered descending roots =
+        let rec treeToList acc = function
+            | (Node (x, aux, children)::ts)::tls ->
+                let nacc = aux |> List.fold (fun xs x -> x::xs) (x::acc)
+                treeToList nacc (children::ts::tls)
+            | []::tls -> treeToList acc tls
+            | [] -> acc
+        let sorted =
+            [(roots |> List.map getTree)]
+            |> treeToList []
+            |> List.sort
+        if descending
+            then sorted |> List.rev
+            else sorted
+        
+//****************************************************************************************************
+type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 'T SBHTreeRoot list) = 
+        
+    new() = SkewBinomialHeap(0, false, [])
+
+    new(descending) = SkewBinomialHeap(0, descending, [])
+
+    static member Empty descending = SkewBinomialHeap (0, descending,[])
+
+    member private this.Roots = roots
+        
+    member this.Count = count
+
+    member this.IsDescending = descending
+
+    member this.IsEmpty = count = 0
+
+    member this.Insert value =
+        SkewBinomialHeap (count + 1, descending, SBHTreeRoot.insert descending value roots)
+
+    member this.TryMerge (other: 'T SkewBinomialHeap) =
+        if descending = other.IsDescending 
+            then Some (SkewBinomialHeap (count + other.Count, descending, SBHTreeRoot.mergeRoots descending (SBHTreeRoot.normalize descending roots) (SBHTreeRoot.normalize descending other.Roots)))
+            else None
+
+    member this.Merge (other: 'T SkewBinomialHeap) =
+        match this.TryMerge other with
+        | Some h -> h
+        | _      -> raise (IncompatibleMerge "Can not merge two heaps with diferent comparison methods")
+
+    member this.TryHead () =
+        if count = 0
+            then None
+            else Some (SBHTreeRoot.findMinRootItem descending roots)
+
+    member this.Head () =
+        match this.TryHead () with
+        | Some h -> h
+        | _      -> raise (Empty "Empty heap, no head")
+
+    member this.TryTail () =
+        if count = 0 then
+            None
+        else
+            //find the root with the minimum value a return it along with the remaining roots
+            let (Root(rank, Node(_, aux, children)), roots') = SBHTreeRoot.extractMinRoot descending roots
+
+            //reverse the children a set their ranks based on the parent's rank
+            let (_, reversed) = children |> List.fold (fun (rank, trees) tree -> rank - 1, Root(rank - 1, tree)::trees) (rank, [])
+
+            //merge the reversed children with the remaining trees
+            let merged = SBHTreeRoot.mergeRoots descending reversed (SBHTreeRoot.normalize descending roots') 
+
+            //reinsert all "auxiliary" elements
+            let newRoots = aux |> List.fold (fun roots value -> SBHTreeRoot.insert descending value roots) merged
+
+            Some (SkewBinomialHeap (count - 1, descending, newRoots))
+
+    member this.Tail () =
+        match this.TryTail () with
+        | Some t -> t
+        | _      -> raise (Empty "Empty heap, no tail")
+
+    member this.TryUncons () =
+        this.TryHead() |> Option.map (fun h -> h, this.Tail())
+
+    member this.Uncons () =
+        match this.TryUncons () with
+        | Some t -> t
+        | None   -> raise (Empty "Empty heap, no head and no tail")
+
+    member this.ToList () =
+        SBHTreeRoot.toListOrdered descending roots
+
+    interface IEnumerable<'T> with
+        member this.GetEnumerator () = (SBHTreeRoot.toListOrdered descending roots |> List.toSeq).GetEnumerator ()
+        
+        member this.GetEnumerator (): System.Collections.IEnumerator = upcast (this :> _ seq).GetEnumerator ()        
+
+    interface IHeap<'T SkewBinomialHeap, 'T> with
+        member this.Count () = this.Count
+        
+        member this.Head () = this.Head ()
+        
+        member this.Insert value = this.Insert value
+        
+        member this.IsDescending = this.IsDescending
+        
+        member this.IsEmpty = this.IsEmpty
+        
+        member this.Length () = this.Count
+        
+        member this.Merge other = this.Merge other
+        
+        member this.Tail () = this.Tail ()
+        
+        member this.TryGetHead () = this.TryHead ()
+        
+        member this.TryGetTail () = this.TryTail ()
+        
+        member this.TryMerge other = this.TryMerge other
+        
+        member this.TryUncons () = this.TryUncons ()
+        
+        member this.Uncons () = this.Uncons ()
+
+    interface IPriorityQueue<'T> with
+        
+        member this.Insert value = upcast this.Insert value
+        
+        member this.IsEmpty = this.IsEmpty
+        
+        member this.Length = this.Count
+        
+        member this.Peek () = this.Head ()
+        
+        member this.Pop() = let head, tail = this.Uncons () in head, upcast tail
+        
+        member this.TryPeek() = this.TryHead ()
+        
+        member this.TryPop() = this.TryUncons () |> Option.map (fun (h, t) -> h, upcast t)
+        
+module SkewBinomialHeap =
+    
+    let inline (|Cons|Nil|) (heap: 'T SkewBinomialHeap) = match heap.TryUncons () with | Some (h, t) -> Cons(h, t) | None -> Nil
+
+    ///O(1) - Returns an empty heap.
+    let inline empty descending = SkewBinomialHeap (descending)
+
+    ///O(log n) - Returns the element at the front. Throws if empty.
+    let inline head (xs: 'T SkewBinomialHeap)  = xs.Head ()
+
+    ///O(log n) - Returns Some x where x is the element at the front.
+    ///Returns None if the collection is empty.
+    let inline tryHead (xs: 'T SkewBinomialHeap)  = xs.TryHead ()
+
+    ///O(1) - Returns a new heap with the element inserted.
+    let inline insert x (xs: 'T SkewBinomialHeap) = xs.Insert x
+
+    ///O(1) - Returns true if the heap has no elements.
+    let inline isEmpty (xs: 'T SkewBinomialHeap) = xs.IsEmpty
+
+    ///O(1) - Returns true if a call to head of tryHead would return the maximum element in the collection.
+    /// Returns false if the element at the head is the minimum.
+    let inline isDescending (xs: 'T SkewBinomialHeap) = xs.IsDescending
+
+    ///O(1) - Returns the number of elememts in the collection.
+    let inline length (xs: 'T SkewBinomialHeap) = xs.Count 
+
+    ///O(log n) - Returns a new heap with the elements of both heaps. The two heaps must have the same isDescending value.
+    let inline merge (xs: 'T SkewBinomialHeap) (ys: 'T SkewBinomialHeap) = xs.Merge ys
+
+    ///O(log n) - Returns Some h where h is the merged heap, is both original heaps have the same isDescending value.
+    /// Returns None if isDescending is diferent in the heaps supplied.
+    let inline tryMerge (xs: 'T SkewBinomialHeap) (ys: 'T SkewBinomialHeap) = xs.TryMerge ys
+
+    ///O(n) - Returns heap from the sequence.
+    let ofSeq descending s = s |> Seq.fold (fun heap value -> insert value heap) (empty descending)
+
+    ///O(log n) - Returns a new heap with the front (head) element removed. Throws if empty.
+    let inline tail (xs: 'T SkewBinomialHeap) = xs.Tail ()
+
+    ///O(log n) - Returns Some h where h is the heap with the front (head) element removed.
+    /// Returns None if the collection is empty.
+    let inline tryGetTail (xs: 'T SkewBinomialHeap) = xs.TryTail()
+
+    /// O(log n) - Returns the head element and tail. Throws if empty.
+    let inline uncons (xs: 'T SkewBinomialHeap) = xs.Uncons()
+
+    /// O(log n) - Returns Some (h, t) where h is the head and t is the tail.
+    /// Returns None if the collection is empty.
+    let inline tryUncons (xs: 'T SkewBinomialHeap) = xs.TryUncons()
+
+    /// O(n * log n) - Returns and ordered sequence of the elements in the heap.
+    let inline toSeq (xs: 'T SkewBinomialHeap) = xs :> 'T IEnumerable
+
+    /// O(n * log n) - Returns and ordered list of the elements in the heap.
+    let inline toList (xs: 'T SkewBinomialHeap) = xs.ToList()

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -101,8 +101,11 @@ module private SBHTreeRoot =
             else sorted
         
 //****************************************************************************************************
-//TODO: Implement equality to be able to compare two heaps
 //TODO: Maybe implement comparison too?
+/// A SkewBinomialHeap is a priority queue where elements are inserted in any order, using "insert" and are 
+/// extracted in either ascending or descending order using "head", "peek", "tail", "pop" or any of their 
+/// "try" variants. The main advantage of the SkewBinomialHeap over the BinomialHeap is that it supports
+/// insertions in constant time O(1). (Based on "Purely Functional Data Structures" - 1996 by Chris Okasaki)
 type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 'T SBHTreeRoot list) =
     
     static let hashElements = 20

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -11,21 +11,17 @@ type private 'T SBHTree = Node of 'T * 'T list * 'T SBHTree list
 
 type private 'T SBHTreeRoot = Root of int * 'T SBHTree
 
-[<AutoOpen>]
-module private Helper =
-    let inline xor a b = (a && not b) || (not a && b)
-
 module private SBHTree =
     let item (Node (x, _, _)) = x
 
     let link descending (Node (x, auxX, childrenX) as treeX) (Node (y, auxY, childrenY) as treeY) =
-        if xor (x <= y) descending
+        if x <= y <> descending
             then Node (x, auxX, treeY::childrenX)
             else Node (y, auxY, treeX::childrenY)
 
     let skewLink descending v treeX treeY =
         let (Node (w, aux, children)) = link descending treeX treeY
-        if xor (v <= w) descending
+        if v <= w <> descending
             then Node (v, w::aux, children)
             else Node (w, v::aux, children)
 
@@ -59,7 +55,7 @@ module private SBHTreeRoot =
         | [p] -> (p, [])
         | (Root(_, tree) as root)::roots ->
             let (Root(_, tree') as root', roots') = extractMinRoot descending roots
-            if xor (SBHTree.item tree <= SBHTree.item tree') descending
+            if (SBHTree.item tree <= SBHTree.item tree') <> descending
                 then root, roots
                 else root', root::roots'
         | [] -> failwith "This should never happen"
@@ -69,7 +65,7 @@ module private SBHTreeRoot =
         | Root(_, node)::roots'                 -> 
             let this = item node
             let other = findMinRootItem descending roots'
-            if xor (this <= other) descending
+            if this <= other <> descending
                 then this
                 else other
         | []                                    -> failwith "This should never happen"

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -6,6 +6,12 @@ open FSharpx.Collections
 open System.Collections.Generic
 
 exception IncompatibleMerge of string
+exception PatternMatchedBug of string * string
+
+[<AutoOpen>]
+module private Helpers =
+    let inline bug pattern =
+        raise (PatternMatchedBug ("This pattern was never meant to be matched", pattern))
 
 type private 'T SBHTree = Node of 'T * 'T list * 'T SBHTree list
 
@@ -58,7 +64,7 @@ module private SBHTreeRoot =
             if (SBHTree.item tree <= SBHTree.item tree') <> descending
                 then root, roots
                 else root', root::roots'
-        | [] -> failwith "This should never happen"
+        | [] -> bug "[]"
         
     let rec findMinRootItem descending = function
         | [Root(_, node)]                       -> item node
@@ -68,7 +74,7 @@ module private SBHTreeRoot =
             if this <= other <> descending
                 then this
                 else other
-        | []                                    -> failwith "This should never happen"
+        | []                                    -> bug "[]"
 
     let uncons descending roots =
         //find the root with the minimum value a return it along with the remaining roots

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -177,6 +177,8 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
 
     interface 'T SkewBinomialHeap System.IEquatable with
         member this.Equals other =
+            descending = other.IsDescending &&
+            count = other.Count &&
             this.ToList () = other.ToList()
 
     override this.Equals other =

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -97,7 +97,6 @@ module private SBHTreeRoot =
             else sorted
         
 //****************************************************************************************************
-//TODO: Maybe implement comparison too?
 /// A SkewBinomialHeap is a priority queue where elements are inserted in any order, using "insert" and are 
 /// extracted in either ascending or descending order using "head", "peek", "tail", "pop" or any of their 
 /// "try" variants. The main advantage of the SkewBinomialHeap over the BinomialHeap is that it supports

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -123,18 +123,18 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
 
     new(descending) = SkewBinomialHeap(0, descending, [])
 
-    member private this.Roots = roots
+    member private __.Roots = roots
         
-    member this.Count = count
+    member __.Count = count
 
-    member this.IsDescending = descending
+    member __.IsDescending = descending
 
-    member this.IsEmpty = count = 0
+    member __.IsEmpty = count = 0
 
-    member this.Insert value =
+    member __.Insert value =
         SkewBinomialHeap (count + 1, descending, SBHTreeRoot.insert descending value roots)
 
-    member this.TryMerge (other: 'T SkewBinomialHeap) =
+    member __.TryMerge (other: 'T SkewBinomialHeap) =
         if descending = other.IsDescending 
             then Some (SkewBinomialHeap (count + other.Count, descending, SBHTreeRoot.mergeRoots descending (SBHTreeRoot.normalize descending roots) (SBHTreeRoot.normalize descending other.Roots)))
             else None
@@ -144,7 +144,7 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
         | Some h -> h
         | _      -> raise (IncompatibleMerge "Can not merge two heaps with diferent comparison methods")
 
-    member this.TryHead () =
+    member __.TryHead () =
         if count = 0
             then None
             else Some (SBHTreeRoot.findMinRootItem descending roots)
@@ -154,7 +154,7 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
         | Some h -> h
         | _      -> invalidOp "Empty heap, no head"
 
-    member this.TryTail () =
+    member __.TryTail () =
         if count = 0 then
             None
         else
@@ -175,7 +175,7 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
         | Some t -> t
         | None   -> invalidOp "Empty heap, no head and no tail"
 
-    member this.ToList () =
+    member __.ToList () =
         SBHTreeRoot.toListOrdered descending roots
 
     interface 'T SkewBinomialHeap System.IEquatable with
@@ -189,10 +189,10 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
         | :? ('T SkewBinomialHeap System.IEquatable) as eheap -> eheap.Equals this
         | _ -> false
 
-    override this.GetHashCode () = match hash with Lazy h -> h
+    override __.GetHashCode () = match hash with Lazy h -> h
 
     interface IEnumerable<'T> with
-        member this.GetEnumerator () = (SBHTreeRoot.toListOrdered descending roots |> List.toSeq).GetEnumerator ()
+        member __.GetEnumerator () = (SBHTreeRoot.toListOrdered descending roots |> List.toSeq).GetEnumerator ()
         
         member this.GetEnumerator (): System.Collections.IEnumerator = upcast (this :> _ seq).GetEnumerator ()        
 

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -255,7 +255,7 @@ module SkewBinomialHeap =
 
     ///O(log n) - Returns Some h where h is the heap with the front (head) element removed.
     /// Returns None if the collection is empty.
-    let inline tryGetTail (xs: 'T SkewBinomialHeap) = xs.TryTail()
+    let inline tryTail (xs: 'T SkewBinomialHeap) = xs.TryTail()
 
     /// O(log n) - Returns the head element and tail. Throws if empty.
     let inline uncons (xs: 'T SkewBinomialHeap) = xs.Uncons()

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -236,8 +236,11 @@ module SkewBinomialHeap =
     /// Returns false if the element at the head is the minimum.
     let inline isDescending (xs: 'T SkewBinomialHeap) = xs.IsDescending
 
-    ///O(1) - Returns the number of elememts in the collection.
-    let inline length (xs: 'T SkewBinomialHeap) = xs.Count 
+    ///O(1) - Returns the number of elements in the collection.
+    let inline length (xs: 'T SkewBinomialHeap) = xs.Count
+
+    ///O(1) - Returns the number of elements in the collection.
+    let inline count (xs: 'T SkewBinomialHeap) = xs.Count
 
     ///O(log n) - Returns a new heap with the elements of both heaps. The two heaps must have the same isDescending value.
     let inline merge (xs: 'T SkewBinomialHeap) (ys: 'T SkewBinomialHeap) = xs.Merge ys

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -97,8 +97,6 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
 
     new(descending) = SkewBinomialHeap(0, descending, [])
 
-    static member Empty descending = SkewBinomialHeap (0, descending,[])
-
     member private this.Roots = roots
         
     member this.Count = count

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -91,6 +91,8 @@ module private SBHTreeRoot =
             else sorted
         
 //****************************************************************************************************
+//TODO: Implement equality to be able to compare two heaps
+//TODO: Maybe implement comparison too?
 type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 'T SBHTreeRoot list) = 
         
     new() = SkewBinomialHeap(0, false, [])

--- a/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
+++ b/src/FSharpx.Collections.Experimental/SkewBinomialHeap.fs
@@ -5,7 +5,6 @@
 open FSharpx.Collections
 open System.Collections.Generic
 
-exception Empty of string //TODO: improve this and include in the exceptions or use the Empty that is already there
 exception IncompatibleMerge of string
 
 type private 'T SBHTree = Node of 'T * 'T list * 'T SBHTree list
@@ -150,7 +149,7 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
     member this.Head () =
         match this.TryHead () with
         | Some h -> h
-        | _      -> raise (Empty "Empty heap, no head")
+        | _      -> invalidOp "Empty heap, no head"
 
     member this.TryTail () =
         if count = 0 then
@@ -161,7 +160,7 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
     member this.Tail () =
         match this.TryTail () with
         | Some t -> t
-        | _      -> raise (Empty "Empty heap, no tail")
+        | _      -> invalidOp "Empty heap, no tail"
 
     member this.TryUncons () =
         if this.IsEmpty 
@@ -171,7 +170,7 @@ type 'T SkewBinomialHeap when 'T: comparison private (count, descending, roots: 
     member this.Uncons () =
         match this.TryUncons () with
         | Some t -> t
-        | None   -> raise (Empty "Empty heap, no head and no tail")
+        | None   -> invalidOp "Empty heap, no head and no tail"
 
     member this.ToList () =
         SBHTreeRoot.toListOrdered descending roots

--- a/tests/FSharpx.Collections.Experimental.Tests/FSharpx.Collections.Experimental.Tests.fsproj
+++ b/tests/FSharpx.Collections.Experimental.Tests/FSharpx.Collections.Experimental.Tests.fsproj
@@ -105,6 +105,7 @@
     <Compile Include="RoseTreeTest.fs" />
     <Compile Include="TimeSeriesTest.fs" />
     <Compile Include="BlockResizeArrayTest.fs" />
+    <Compile Include="SkewBinomialHeapTest.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FSharpx.Collections.Experimental\FSharpx.Collections.Experimental.fsproj">

--- a/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
@@ -293,15 +293,26 @@ let ``Equality reflexivity`` () =
 
 [<Test>]
 let ``Equality symmetry`` () =
-    fsCheck <| fun {Heap = heap } item ->
+    fsCheck <| fun { Heap = heap } item ->
         let heap1 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
         let heap2 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
         heap1 = heap2 ==> (heap2 = heap1)
 
 [<Test>]
 let ``Equality transitivity`` () = //maybe this is too much, I guess It would be hard to write an Equals that violates this property and not the others
-    fsCheck <| fun {Heap = heap } item ->
+    fsCheck <| fun { Heap = heap } item ->
         let heap1 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
         let heap2 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
         let heap3 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
         (heap1 = heap2 && heap2 = heap3) ==> (heap1 = heap3)
+
+[<Test>]
+let ``Equals returns false when comparing two heaps with the same ordering but different items`` () =
+    fsCheck <| fun ({ Heap = heap1; Items = orig1}, { Heap = heap2; Items = orig2}) ->
+        (heap1.IsDescending = heap2.IsDescending && orig1 <> orig2) ==> (heap1 <> heap2 && not (heap1.Equals heap2))
+
+[<Test>]
+let ``Equals returns false when comparing two heaps with the same items but different ordering`` () =
+    fsCheck <| fun { Heap = heap1; Items = orig} ->
+        let heap2 = ofList (not heap1.IsDescending) orig
+        heap1 <> heap2 && not (heap1.Equals heap2)

--- a/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
@@ -144,7 +144,7 @@ let ``head returns the first element when the heap is not empty`` () =
 [<Test>]
 let ``head throws when the heap is empty`` () =
     fsCheck <| fun { Heap = heap } -> 
-        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<Empty> <| fun () -> heap |> SkewBinomialHeap.head |> ignore)
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<InvalidOperationException> <| fun () -> heap |> SkewBinomialHeap.head |> ignore)
 
 [<Test>]
 let ``tryHead returns Some head when the heap is not empty`` () =
@@ -168,7 +168,7 @@ let ``tail returns a heap with the first element removed when the heap is not em
 [<Test>]
 let ``tail throws when the heap is empty`` () =
     fsCheck <| fun { Heap = heap } -> 
-        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<Empty> <| fun () -> heap |> SkewBinomialHeap.tail |> ignore)
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<InvalidOperationException> <| fun () -> heap |> SkewBinomialHeap.tail |> ignore)
 
 [<Test>]
 let ``tryTail returns Some tail when the heap is not empty`` () =
@@ -196,7 +196,7 @@ let ``uncons returns (head, tail) when the heap is not empty`` () =
 [<Test>]
 let ``uncons throws when the heap is empty`` () =
     fsCheck <| fun { Heap = heap } -> 
-        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<Empty> <| fun () -> heap |> SkewBinomialHeap.uncons |> ignore)
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<InvalidOperationException> <| fun () -> heap |> SkewBinomialHeap.uncons |> ignore)
 
 [<Test>]
 let ``tryUncons returns Some (head, tail) when the heap is not empty`` () =

--- a/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
@@ -1,0 +1,213 @@
+﻿[<NUnit.Framework.TestFixture(Category = "SkewBinomialHeap, Heap, Priority Queue")>]
+module FSharpx.Collections.Experimental.Tests.SkewBinomialHeapTest
+
+open FSharpx.Collections.Experimental
+open FsCheck
+open FsCheck.NUnit
+open NUnit.Framework
+open FsUnit
+open System
+
+let ofList desc items = List.fold (fun h x -> SkewBinomialHeap.insert x h) (SkewBinomialHeap.empty desc) items
+
+let sortList heap items = items |> List.sort |> if SkewBinomialHeap.isDescending heap then List.rev else id
+
+let actualHead heap items = items |> if SkewBinomialHeap.isDescending heap then List.max else List.min
+
+let actualTail heap = sortList heap >> List.tail
+
+type ComparableGenerator<'T when 'T :> IComparable> =
+    static member Generate () =
+        gen{
+            let! t = Arb.generate<'T>
+            return (t :> System.IComparable)}
+        |> Arb.fromGen
+
+type HeapData<'T, 'L when 'T: comparison> = { Heap: 'T SkewBinomialHeap; Items: 'L list; Desc: bool }
+
+type SkewBinomialHeapGenerators() =
+    // Empty heaps only, some are empty after removing all its elements
+    static member private EmptyOnly<'T when 'T: comparison> (): Gen<HeapData<'T, 'T>> = gen{
+        let! desc = Gen.elements [true; false]
+        let! s = Gen.listOf (Arb.generate<'T>)
+        return { Heap = Seq.init (s.Length) id |> Seq.fold (fun heap _ -> heap |> SkewBinomialHeap.tail) (ofList desc s); Items = []; Desc = desc }}
+    // Non-emtpy heaps only, after a sucession of insertions and deletions
+    static member private NonemptyOnly<'T when 'T: comparison> (): Gen<HeapData<'T, 'T>> = gen{
+        let! desc = Gen.elements [true; false]
+        let! t = Gen.elements [true; false]
+        let! s = Gen.nonEmptyListOf (Arb.generate<'T>)
+        let! ndel = if t then Gen.constant Int32.MaxValue else Gen.choose (2, max 2 (s |> List.length))
+        let (heap, list, _) =
+            s 
+            |> List.fold 
+                (fun (heap, lst, k) item ->
+                    let newHeap = heap |> SkewBinomialHeap.insert item
+                    let newList = item::lst
+                    if k + 1 = ndel then
+                        (newHeap |> SkewBinomialHeap.tail, newList |> List.sort |> (if desc then List.rev else id) |> List.tail, 0)
+                    else
+                        (newHeap, newList, k + 1))
+                (SkewBinomialHeap.empty desc, [], 0)
+        return {Heap = heap; Items = list; Desc = desc}}
+    
+    static member private Mixed<'T when 'T: comparison> (): Gen<HeapData<'T, 'T>> =
+        Gen.frequency [200, SkewBinomialHeapGenerators.EmptyOnly<'T> (); 800, SkewBinomialHeapGenerators.NonemptyOnly<'T> ()]
+
+    static member private TwoMixed<'T when 'T: comparison> (): Gen<HeapData<'T, 'T> * HeapData<'T, 'T>> =
+        Gen.frequency [
+            200, SkewBinomialHeapGenerators.EmptyOnly<'T> () |> Gen.two; 
+            400, SkewBinomialHeapGenerators.NonemptyOnly<'T> () |> Gen.two;
+            200, gen{ 
+                let! e = SkewBinomialHeapGenerators.EmptyOnly<'T>()
+                let! n = SkewBinomialHeapGenerators.EmptyOnly<'T>()
+                return (e, n)}
+            200, gen{ 
+                let! e = SkewBinomialHeapGenerators.EmptyOnly<'T>()
+                let! n = SkewBinomialHeapGenerators.EmptyOnly<'T>()
+                return (n, e)}]
+
+    static member ComparableAndComparable() = SkewBinomialHeapGenerators.Mixed<IComparable> () |> Arb.fromGen
+
+    static member ComparableAndComparablePair() = SkewBinomialHeapGenerators.TwoMixed<IComparable>() |> Arb.fromGen
+
+    static member ComparableAndObject() = gen {
+        let! data = SkewBinomialHeapGenerators.Mixed<IComparable> ()
+        return { Heap = data.Heap; Items = data.Items |> Seq.cast<obj> |> Seq.toList; Desc = data.Desc }} |> Arb.fromGen
+        
+    static member ComparableAndObjectPair() = gen {
+        let! data1, data2 = SkewBinomialHeapGenerators.TwoMixed<IComparable> ()
+        return { Heap = data1.Heap; Items = data1.Items |> Seq.cast<obj> |> Seq.toList; Desc = data1.Desc },
+               { Heap = data2.Heap; Items = data2.Items |> Seq.cast<obj> |> Seq.toList; Desc = data2.Desc }} |> Arb.fromGen
+
+let register = 
+    lazy (
+        Arb.register<ComparableGenerator<string>>() |> ignore
+        Arb.register<SkewBinomialHeapGenerators>() |> ignore)
+
+[<TestFixtureSetUp>]
+let setUp () =
+    register.Force ()
+
+let fail str = Assert.Fail str
+
+let fsCheck a = fsCheck null a
+
+//************* TESTS *****************
+
+[<Test>]
+let ``toSeq returns all the elements`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } -> 
+        heap |> SkewBinomialHeap.toSeq |> Seq.toList |> List.sort = List.sort orig
+
+[<Test>]
+let ``toSeq returns the elements in the correct order`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } -> 
+        heap |> SkewBinomialHeap.toSeq |> Seq.toList = sortList heap orig
+
+[<Test>]
+let ``toList returns the same as toSeq |> List.ofSeq`` () =
+    fsCheck <| fun { Heap = heap } ->
+        heap |> SkewBinomialHeap.toList = (heap |> SkewBinomialHeap.toSeq |> List.ofSeq)
+
+[<Test>]
+let ``isDescending returns correct value`` () =
+    fsCheck <| fun { Heap = heap; Desc = desc } ->
+        SkewBinomialHeap.isDescending heap = desc
+
+[<Test>]
+let ``isEmpty returns true if count = 0, false otherwise`` () =
+    fsCheck <| fun { Heap = heap } ->
+        SkewBinomialHeap.count heap = 0 = SkewBinomialHeap.isEmpty heap
+
+[<Test>]
+let ``isEmpty returns true if the heap is empty, false otherwise`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } ->
+        SkewBinomialHeap.isEmpty heap = List.isEmpty orig
+
+[<Test>]
+let ``count returns the number of elements`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } ->
+        heap |> SkewBinomialHeap.count = List.length orig
+
+[<Test>]
+let ``length is the same as count`` () =
+    fsCheck <| fun { Heap = heap } ->
+        heap |> SkewBinomialHeap.count = SkewBinomialHeap.length heap
+
+[<Test>]
+let ``head returns the first element when the heap is not empty`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } -> 
+        heap |> SkewBinomialHeap.isEmpty |> not ==> lazy(heap |> SkewBinomialHeap.head |> should equal <| actualHead heap orig)
+
+[<Test>]
+let ``head throws when the heap is empty`` () =
+    fsCheck <| fun { Heap = heap } -> 
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<Empty> <| fun () -> heap |> SkewBinomialHeap.head |> ignore)
+
+[<Test>]
+let ``tryHead returns Some head when the heap is not empty`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } -> 
+        heap |> SkewBinomialHeap.isEmpty |> not ==> 
+            lazy(
+                match SkewBinomialHeap.tryHead heap with 
+                | Some head -> head |> should equal <| actualHead heap orig
+                | None -> fail "tryHead to a non-empty heap returned None")
+
+[<Test>]
+let ``tryHead returns None when the heap is empty`` () =
+    fsCheck <| fun { Heap = heap } ->
+        heap |> SkewBinomialHeap.isEmpty ==> lazy (heap |> SkewBinomialHeap.tryHead |> Option.isNone)
+
+[<Test>]
+let ``tail returns a heap with the first element removed when the heap is not empty`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } ->
+        heap |> SkewBinomialHeap.isEmpty |> not ==> lazy(heap |> SkewBinomialHeap.tail |> SkewBinomialHeap.toList |> should equal <| actualTail heap orig)
+
+[<Test>]
+let ``tail throws when the heap is empty`` () =
+    fsCheck <| fun { Heap = heap } -> 
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<Empty> <| fun () -> heap |> SkewBinomialHeap.tail |> ignore)
+
+[<Test>]
+let ``tryTail returns Some tail when the heap is not empty`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } -> 
+        heap |> SkewBinomialHeap.isEmpty |> not ==> 
+            lazy(
+                match SkewBinomialHeap.tryTail heap with 
+                | Some tail -> tail |> SkewBinomialHeap.toList |> should equal <| actualTail heap orig
+                | None -> fail "tryTail to a non-empty heap returned None")
+
+[<Test>]
+let ``tryTail returns None when the heap is empty`` () =
+    fsCheck <| fun { Heap = heap } ->
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(heap |> SkewBinomialHeap.tryTail |> Option.isNone)
+
+[<Test>]
+let ``uncons returns (head, tail) when the heap is not empty`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } -> 
+        heap |> SkewBinomialHeap.isEmpty |> not ==> 
+            lazy(
+                let (h, t) = SkewBinomialHeap.uncons heap
+                h |> should equal <| actualHead heap orig
+                t |> SkewBinomialHeap.toList |> should equal <| actualTail heap orig)
+
+[<Test>]
+let ``uncons throws when the heap is empty`` () =
+    fsCheck <| fun { Heap = heap } -> 
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(should throw typeof<Empty> <| fun () -> heap |> SkewBinomialHeap.uncons |> ignore)
+
+[<Test>]
+let ``tryUncons returns Some (head, tail) when the heap is not empty`` () =
+    fsCheck <| fun { Heap = heap; Items = orig } -> 
+        heap |> SkewBinomialHeap.isEmpty |> not ==> 
+            lazy(
+                match SkewBinomialHeap.tryUncons heap with 
+                | Some (h, t) ->
+                    h |> should equal (actualHead heap orig)
+                    t |> SkewBinomialHeap.toList |> should equal (actualTail heap orig)
+                | None -> fail "tryUncons to a non-empty heap returned None")
+
+[<Test>]
+let ``tryUncons returns None when the heap is empty`` () =
+    fsCheck <| fun { Heap = heap } ->
+        heap |> SkewBinomialHeap.isEmpty ==> lazy(heap |> SkewBinomialHeap.tryUncons |> Option.isNone)

--- a/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
@@ -27,14 +27,18 @@ type ComparableGenerator<'T when 'T :> IComparable> =
 type HeapData<'T, 'L when 'T: comparison> = { Heap: 'T SkewBinomialHeap; Items: 'L list; Desc: bool }
 
 type SkewBinomialHeapGenerators() =
+    static let genDesc d = 
+        match d with
+        | Some v -> Gen.constant v
+        | None -> Gen.elements [true; false]
     // Empty heaps only, some are empty after removing all of its elements
-    static member private EmptyOnly<'T when 'T: comparison> (): Gen<HeapData<'T, 'T>> = gen{
-        let! desc = Gen.elements [true; false]
+    static member private EmptyOnly<'T when 'T: comparison> (d): Gen<HeapData<'T, 'T>> = gen{
+        let! desc = genDesc d
         let! s = Gen.listOf (Arb.generate<'T>)
         return { Heap = Seq.init (s.Length) id |> Seq.fold (fun heap _ -> heap |> SkewBinomialHeap.tail) (ofList desc s); Items = []; Desc = desc }}
     // Non-emtpy heaps only, after a sucession of insertions and deletions
-    static member private NonemptyOnly<'T when 'T: comparison> (): Gen<HeapData<'T, 'T>> = gen{
-        let! desc = Gen.elements [true; false]
+    static member private NonemptyOnly<'T when 'T: comparison> (d): Gen<HeapData<'T, 'T>> = gen{
+        let! desc = genDesc d
         let! t = Gen.elements [true; false]
         let! s = Gen.nonEmptyListOf (Arb.generate<'T>)
         let! ndel = if t then Gen.constant Int32.MaxValue else Gen.choose (2, max 2 (s |> List.length))
@@ -52,20 +56,15 @@ type SkewBinomialHeapGenerators() =
         return {Heap = heap; Items = list; Desc = desc}}
     
     static member private Mixed<'T when 'T: comparison> (): Gen<HeapData<'T, 'T>> =
-        Gen.frequency [200, SkewBinomialHeapGenerators.EmptyOnly<'T> (); 800, SkewBinomialHeapGenerators.NonemptyOnly<'T> ()]
+        Gen.frequency [200, SkewBinomialHeapGenerators.EmptyOnly<'T> (None); 800, SkewBinomialHeapGenerators.NonemptyOnly<'T> (None)]
 
+    //Distribute the cases, so the tests that receive two heaps and need both to have the same isDescending don't exhaust the arguments, ex: the merge tests
     static member private TwoMixed<'T when 'T: comparison> (): Gen<HeapData<'T, 'T> * HeapData<'T, 'T>> =
         Gen.frequency [
-            200, SkewBinomialHeapGenerators.EmptyOnly<'T> () |> Gen.two; 
-            400, SkewBinomialHeapGenerators.NonemptyOnly<'T> () |> Gen.two;
-            200, gen{ 
-                let! e = SkewBinomialHeapGenerators.EmptyOnly<'T>()
-                let! n = SkewBinomialHeapGenerators.EmptyOnly<'T>()
-                return (e, n)}
-            200, gen{ 
-                let! e = SkewBinomialHeapGenerators.EmptyOnly<'T>()
-                let! n = SkewBinomialHeapGenerators.EmptyOnly<'T>()
-                return (n, e)}]
+            500, Gen.oneof [SkewBinomialHeapGenerators.EmptyOnly<'T> (None); SkewBinomialHeapGenerators.NonemptyOnly<'T> (None)] |> Gen.two
+            250, Gen.oneof [SkewBinomialHeapGenerators.EmptyOnly<'T> (Some true); SkewBinomialHeapGenerators.NonemptyOnly<'T> (Some true)] |> Gen.two
+            250, Gen.oneof [SkewBinomialHeapGenerators.EmptyOnly<'T> (Some false); SkewBinomialHeapGenerators.NonemptyOnly<'T> (Some false)] |> Gen.two
+            ]
 
     static member ComparableAndComparable() = SkewBinomialHeapGenerators.Mixed<IComparable> () |> Arb.fromGen
 
@@ -95,6 +94,7 @@ let fsCheck a = fsCheck null a
 
 //************* TESTS *****************
 //Only tested the functions on the SkewBinomialHeap module for now, later I could test the remaining functions and methods
+//TODO: Test ofSeq
 
 [<Test>]
 let ``toSeq returns all the elements`` () =
@@ -139,7 +139,7 @@ let ``length is the same as count`` () =
 [<Test>]
 let ``head returns the first element when the heap is not empty`` () =
     fsCheck <| fun { Heap = heap; Items = orig } -> 
-        heap |> SkewBinomialHeap.isEmpty |> not ==> lazy(heap |> SkewBinomialHeap.head |> should equal <| actualHead heap orig)
+        heap |> SkewBinomialHeap.isEmpty |> not ==> lazy(heap |> SkewBinomialHeap.head = actualHead heap orig)
 
 [<Test>]
 let ``head throws when the heap is empty`` () =
@@ -150,20 +150,19 @@ let ``head throws when the heap is empty`` () =
 let ``tryHead returns Some head when the heap is not empty`` () =
     fsCheck <| fun { Heap = heap; Items = orig } -> 
         heap |> SkewBinomialHeap.isEmpty |> not ==> 
-            lazy(
-                match SkewBinomialHeap.tryHead heap with 
-                | Some head -> head |> should equal <| actualHead heap orig
-                | None -> fail "tryHead to a non-empty heap returned None")
+        match SkewBinomialHeap.tryHead heap with 
+        | Some head -> head = actualHead heap orig
+        | None -> false
 
 [<Test>]
 let ``tryHead returns None when the heap is empty`` () =
     fsCheck <| fun { Heap = heap } ->
-        heap |> SkewBinomialHeap.isEmpty ==> lazy (heap |> SkewBinomialHeap.tryHead |> Option.isNone)
+        heap |> SkewBinomialHeap.isEmpty ==> (heap |> SkewBinomialHeap.tryHead |> Option.isNone)
 
 [<Test>]
 let ``tail returns a heap with the first element removed when the heap is not empty`` () =
     fsCheck <| fun { Heap = heap; Items = orig } ->
-        heap |> SkewBinomialHeap.isEmpty |> not ==> lazy(heap |> SkewBinomialHeap.tail |> SkewBinomialHeap.toList |> should equal <| actualTail heap orig)
+        heap |> SkewBinomialHeap.isEmpty |> not ==> lazy(heap |> SkewBinomialHeap.tail |> SkewBinomialHeap.toList = actualTail heap orig)
 
 [<Test>]
 let ``tail throws when the heap is empty`` () =
@@ -176,13 +175,13 @@ let ``tryTail returns Some tail when the heap is not empty`` () =
         heap |> SkewBinomialHeap.isEmpty |> not ==> 
             lazy(
                 match SkewBinomialHeap.tryTail heap with 
-                | Some tail -> tail |> SkewBinomialHeap.toList |> should equal <| actualTail heap orig
-                | None -> fail "tryTail to a non-empty heap returned None")
+                | Some tail -> tail |> SkewBinomialHeap.toList = actualTail heap orig
+                | None -> false)
 
 [<Test>]
 let ``tryTail returns None when the heap is empty`` () =
     fsCheck <| fun { Heap = heap } ->
-        heap |> SkewBinomialHeap.isEmpty ==> lazy(heap |> SkewBinomialHeap.tryTail |> Option.isNone)
+        heap |> SkewBinomialHeap.isEmpty ==> (heap |> SkewBinomialHeap.tryTail |> Option.isNone)
 
 [<Test>]
 let ``uncons returns (head, tail) when the heap is not empty`` () =
@@ -190,8 +189,8 @@ let ``uncons returns (head, tail) when the heap is not empty`` () =
         heap |> SkewBinomialHeap.isEmpty |> not ==> 
             lazy(
                 let (h, t) = SkewBinomialHeap.uncons heap
-                h |> should equal <| actualHead heap orig
-                t |> SkewBinomialHeap.toList |> should equal <| actualTail heap orig)
+                h = actualHead heap orig &&
+                SkewBinomialHeap.toList t = actualTail heap orig)
 
 [<Test>]
 let ``uncons throws when the heap is empty`` () =
@@ -205,9 +204,9 @@ let ``tryUncons returns Some (head, tail) when the heap is not empty`` () =
             lazy(
                 match SkewBinomialHeap.tryUncons heap with 
                 | Some (h, t) ->
-                    h |> should equal (actualHead heap orig)
-                    t |> SkewBinomialHeap.toList |> should equal (actualTail heap orig)
-                | None -> fail "tryUncons to a non-empty heap returned None")
+                    h = actualHead heap orig &&
+                    SkewBinomialHeap.toList t = actualTail heap orig
+                | None -> false)
 
 [<Test>]
 let ``tryUncons returns None when the heap is empty`` () =
@@ -224,7 +223,7 @@ let ``insert always insert`` () =
 
 [<Test>]
 let ``merge should merge if both heaps have the same ordering`` () =
-    fsCheck <| fun { Heap = heap1; Items = orig1 } { Heap = heap2; Items = orig2 } ->
+    fsCheck <| fun ({ Heap = heap1; Items = orig1 }, { Heap = heap2; Items = orig2 }) ->
         heap1.IsDescending = heap2.IsDescending ==>
         lazy(
             SkewBinomialHeap.merge heap1 heap2 
@@ -233,22 +232,22 @@ let ``merge should merge if both heaps have the same ordering`` () =
 
 [<Test>]
 let ``merge throws when both heaps have diferent ordering`` () =
-    fsCheck <| fun { Heap = heap1 } { Heap = heap2 } ->
+    fsCheck <| fun ({ Heap = heap1 }, { Heap = heap2 }) ->
         heap1.IsDescending <> heap2.IsDescending ==>
         lazy(should throw typeof<IncompatibleMerge> <| fun () -> SkewBinomialHeap.merge heap1 heap2 |> ignore)
 
 [<Test>]
 let ``tryMerge returns Some merged heap when both heaps have the same ordering`` () =
-    fsCheck <| fun { Heap = heap1; Items = orig1 } { Heap = heap2; Items = orig2 } ->
+    fsCheck <| fun ({ Heap = heap1; Items = orig1 }, { Heap = heap2; Items = orig2 }) ->
         heap1.IsDescending = heap2.IsDescending ==>
         lazy(
             match SkewBinomialHeap.tryMerge heap1 heap2 |> Option.map SkewBinomialHeap.toList with
-            | Some list -> list |> should equal (orig1 |> List.append orig2 |> sortList heap1)
-            | None -> fail "tryMerge returned None when called with two compatible heaps")
+            | Some list -> list = (List.append orig1 orig2 |> sortList heap1)
+            | None -> false)
 
 [<Test>]
 let ``tryMerge returns None when both heaps have diferent ordering`` () =
-    fsCheck <| fun { Heap = heap1; Items = orig1 } { Heap = heap2; Items = orig2 } ->
+    fsCheck <| fun ({ Heap = heap1; Items = orig1 }, { Heap = heap2; Items = orig2 }) ->
         heap1.IsDescending <> heap2.IsDescending ==> lazy(SkewBinomialHeap.tryMerge heap1 heap2 |> Option.isNone)
 
 [<Test>]
@@ -269,10 +268,40 @@ let ``Nil pattern always match if the heap is empty`` () =
 
 [<Test>]
 let ``Cons pattern return the same as uncons`` () =
-    fsCheck <| fun { Heap = heap; Items = orig } ->
+    fsCheck <| fun { Heap = heap } ->
         heap |> SkewBinomialHeap.isEmpty |> not ==>
         match heap with
         | SkewBinomialHeap.Cons (h, t) ->
             let (h', t') = heap |> SkewBinomialHeap.uncons
-            h = h' && SkewBinomialHeap.toList t = SkewBinomialHeap.toList t'
+            h = h' && t = t'
         | _ -> false
+
+[<Test>]
+let ``GetHashCode is the same for equal heaps`` () =
+    fsCheck <| fun { Heap = heap } item ->
+        let heap1 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
+        let heap2 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
+        Unchecked.hash heap1 = Unchecked.hash heap2
+
+//Maybe the distribution of the hash should be checked
+//to avoid bad hashes, I don't know if that should be done as part of unit testing
+
+[<Test>]
+let ``Equality reflexivity`` () =
+    fsCheck <| fun { Heap = heap } ->
+        heap = heap
+
+[<Test>]
+let ``Equality symmetry`` () =
+    fsCheck <| fun {Heap = heap } item ->
+        let heap1 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
+        let heap2 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
+        heap1 = heap2 ==> (heap2 = heap1)
+
+[<Test>]
+let ``Equality transitivity`` () = //maybe this is too much, I guess It would be hard to write an Equals that violates this property and not the others
+    fsCheck <| fun {Heap = heap } item ->
+        let heap1 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
+        let heap2 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
+        let heap3 = heap |> SkewBinomialHeap.insert item |> SkewBinomialHeap.tail
+        (heap1 = heap2 && heap2 = heap3) ==> (heap1 = heap3)


### PR DESCRIPTION
Here it is my implementation of the skew binomial heap of Okasaki, but without storing the rank or weight in the subtrees, only in the roots. That helps to reduce some overhead. Almost all the functions of the module are tested. I did not write any test for the methods, though all are used through the let bound function in the module, so in a way they can be considered tested; that is still work to do. I hope you like it.