### PR TITLE
Fix doc errors

### DIFF
--- a/src/FSharpx.Collections/DList.fsi
+++ b/src/FSharpx.Collections/DList.fsi
@@ -37,7 +37,7 @@ type DList<'T> =
     ///O(log n). Returns the first element and tail.
     member Uncons : 'T * DList<'T> 
  
-    ///O((log n). Returns option first element and tail.
+    ///O(log n). Returns option first element and tail.
     member TryUncons : ('T * DList<'T>) option
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/src/FSharpx.Collections/Deque.fsi
+++ b/src/FSharpx.Collections/Deque.fsi
@@ -79,10 +79,10 @@ module Deque =
     [<GeneralizableValue>]
     val empty<'T> : Deque<'T>
 
-    /// O(n). Applies a function to each element of the deque, threading an accumulator argument through the computation, left to right
+    ///O(n). Applies a function to each element of the deque, threading an accumulator argument through the computation, left to right
     val fold : ('State -> 'T -> 'State) -> 'State -> Deque<'T> -> 'State
 
-    /// O(n). Applies a function to each element of the deque, threading an accumulator argument through the computation, right to left
+    ///O(n). Applies a function to each element of the deque, threading an accumulator argument through the computation, right to left
     val foldBack : ('T -> 'State -> 'State) -> Deque<'T> -> 'State -> 'State
 
     ///O(1) amortized, O(n), worst case. Returns the first element.

--- a/src/FSharpx.Collections/PersistentVector.fsi
+++ b/src/FSharpx.Collections/PersistentVector.fsi
@@ -2,8 +2,10 @@
 #if FX_NO_THREAD
 #else
 /// PersistentVector is an ordered linear structure implementing the inverse of the List signature, 
-/// (last, initial, conj) in place of (head, tail, cons). Indexed lookup or update 
-/// (returning a new immutable instance of Vector) of any element is O(log32n). Length is O(1). 
+/// (last, initial, conj) in place of (head, tail, cons). Length is O(1). Indexed lookup or update
+/// (returning a new immutable instance of Vector) of any element is O(log32n), which is close enough
+/// to O(1) as to make no practical difference: a PersistentVector containing 4 billion items can
+/// lookup or update any item in at most 7 steps.
 /// Ordering is by insertion history. The original idea can be found in [Clojure](http://clojure.org/data_structures).
 [<Class>]
 type PersistentVector<'T> =
@@ -14,10 +16,10 @@ type PersistentVector<'T> =
     /// O(1). Returns a new vector with the element added at the end.
     member Conj : 'T -> PersistentVector<'T>
          
-    /// O(n). Returns a new vector without the last item. If the collection is empty it throws an exception.
+    /// O(1) for all practical purposes; really O(log32n). Returns a new vector without the last item. If the collection is empty it throws an exception.
     member Initial : PersistentVector<'T>
 
-    /// O(n). Returns option vector without the last item.
+    /// O(1) for all practical purposes; really O(log32n). Returns option vector without the last item.
     member TryInitial : PersistentVector<'T> option
 
     /// O(1). Returns true if the vector has no elements.
@@ -26,7 +28,7 @@ type PersistentVector<'T> =
     /// O(1). Returns a new PersistentVector with no elements.
     static member Empty : unit -> PersistentVector<'T>
 
-    /// O(log32n). Returns vector element at the index.
+    /// O(1) for all practical purposes; really O(log32n). Returns vector element at the index.
     member Item : int -> 'T with get
 
     /// O(1). Returns the last element in the vector. If the vector is empty it throws an exception.
@@ -38,19 +40,19 @@ type PersistentVector<'T> =
     /// O(1). Returns the number of items in the vector.
     member Length : int
 
-    ///O(n). Returns random access list reversed.
+    /// O(n). Returns random access list reversed.
     member Rev : unit -> PersistentVector<'T>
 
-    /// O(n). Returns tuple last element and vector without last item
+    /// O(1) for all practical purposes; really O(log32n). Returns tuple last element and vector without last item
     member Unconj : PersistentVector<'T> * 'T
 
-    /// O(n). Returns option tuple last element and vector without last item
+    /// O(1) for all practical purposes; really O(log32n). Returns option tuple last element and vector without last item
     member TryUnconj : (PersistentVector<'T> * 'T) option
 
-    /// O(log32n). Returns a new vector that contains the given value at the index.
+    /// O(1) for all practical purposes; really O(log32n). Returns a new vector that contains the given value at the index.
     member Update : int * 'T -> PersistentVector<'T> 
             
-    /// O(log32n). Returns option vector that contains the given value at the index.
+    /// O(1) for all practical purposes; really O(log32n). Returns option vector that contains the given value at the index.
     member TryUpdate : int * 'T -> PersistentVector<'T> option
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
@@ -65,15 +67,15 @@ module PersistentVector =
     /// O(1). Returns a new vector with the element added at the end.   
     val inline conj : 'T -> PersistentVector<'T> -> PersistentVector<'T>
 
-    ///O(1). Returns vector of no elements.
+    /// O(1). Returns vector of no elements.
     [<GeneralizableValue>]
     val empty<'T> : PersistentVector<'T>
 
-    /// O(n). Returns a state from the supplied state and a function operating from left to right.
-    val inline fold : ('State -> 'T -> 'State) -> 'State -> PersistentVector<'T> -> 'State
-
     /// O(m,n). Returns a seq from a vector of vectors.
     val inline flatten : PersistentVector<PersistentVector<'T>> -> seq<'T>
+
+    /// O(n). Returns a state from the supplied state and a function operating from left to right.
+    val inline fold : ('State -> 'T -> 'State) -> 'State -> PersistentVector<'T> -> 'State
 
     /// O(n). Returns a state from the supplied state and a function operating from right to left.
     val inline foldBack : ('T -> 'State -> 'State) -> PersistentVector<'T> -> 'State -> 'State
@@ -81,10 +83,10 @@ module PersistentVector =
     /// O(n). Returns a vector of the supplied length using the supplied function operating on the index. 
     val init : int -> (int -> 'T) -> PersistentVector<'T>
 
-    /// O(n). Returns a new vector without the last item. If the collection is empty it throws an exception.
+    /// O(1) for all practical purposes; really O(log32n). Returns a new vector without the last item. If the collection is empty it throws an exception.
     val inline initial : PersistentVector<'T> -> PersistentVector<'T>
 
-    /// O(n). Returns option vector without the last item.
+    /// O(1) for all practical purposes; really O(log32n). Returns option vector without the last item.
     val inline tryInitial : PersistentVector<'T> -> PersistentVector<'T> option
 
     /// O(1). Returns true if the vector has no elements.
@@ -102,13 +104,13 @@ module PersistentVector =
     /// O(n). Returns a vector whose elements are the results of applying the supplied function to each of the elements of a supplied vector.
     val map : ('T -> 'T1) -> PersistentVector<'T> -> PersistentVector<'T1>
 
-    /// O(log32n). Returns the value at the index. If the index is out of bounds it throws an exception.
+    /// O(1) for all practical purposes; really O(log32n). Returns the value at the index. If the index is out of bounds it throws an exception.
     val inline nth : int -> PersistentVector<'T> -> 'T
 
     /// O(log32(m,n)). Returns the value at the  outer index, inner index. If either index is out of bounds it throws an exception.
     val inline nthNth : int -> int -> PersistentVector<PersistentVector<'T>> -> 'T
  
-    /// O(log32n). Returns option value at the index. 
+    /// O(1) for all practical purposes; really O(log32n). Returns option value at the index.
     val inline tryNth : int -> PersistentVector<'T> -> 'T option
 
     /// O(log32(m,n)). Returns option value at the indices. 
@@ -117,28 +119,28 @@ module PersistentVector =
     /// O(n). Returns a vector of the seq.
     val ofSeq : seq<'T> -> PersistentVector<'T>
 
-    ///O(n). Returns vector reversed.
+    /// O(n). Returns vector reversed.
     val inline rev : PersistentVector<'T> -> PersistentVector<'T>
 
     /// O(1). Returns a new vector of one element.   
     val inline singleton : 'T -> PersistentVector<'T>
 
-    ///O(n). Views the given vector as a sequence.
+    /// O(n). Views the given vector as a sequence.
     val inline toSeq  : PersistentVector<'T> ->  seq<'T>
 
-    /// O(n). Returns tuple last element and vector without last item
+    /// O(1) for all practical purposes; really O(log32n). Returns tuple last element and vector without last item
     val inline unconj : PersistentVector<'T> -> PersistentVector<'T> * 'T
 
-    /// O(n). Returns option tuple last element and vector without last item
+    /// O(1) for all practical purposes; really O(log32n). Returns option tuple last element and vector without last item
     val inline tryUnconj : PersistentVector<'T> -> (PersistentVector<'T> * 'T) option
 
-    /// O(log32n). Returns a new vector that contains the given value at the index. 
+    /// O(1) for all practical purposes; really O(log32n). Returns a new vector that contains the given value at the index.
     val inline update : int -> 'T -> PersistentVector<'T> -> PersistentVector<'T>
 
     /// O(log32(m,n)). Returns a new vector of vectors that contains the given value at the indices. 
     val inline updateNth : int -> int -> 'T -> PersistentVector<PersistentVector<'T>> -> PersistentVector<PersistentVector<'T>>
 
-    /// O(log32n). Returns option vector that contains the given value at the index. 
+    /// O(1) for all practical purposes; really O(log32n). Returns option vector that contains the given value at the index.
     val inline tryUpdate : int -> 'T -> PersistentVector<'T> -> PersistentVector<'T> option
 
     /// O(log32(m,n)). Returns option vector that contains the given value at the indices. 

--- a/src/FSharpx.Collections/PersistentVector.fsi
+++ b/src/FSharpx.Collections/PersistentVector.fsi
@@ -41,10 +41,10 @@ type PersistentVector<'T> =
     ///O(n). Returns random access list reversed.
     member Rev : unit -> PersistentVector<'T>
 
-    /// O(1). Returns tuple last element and vector without last item  
+    /// O(n). Returns tuple last element and vector without last item
     member Unconj : PersistentVector<'T> * 'T
 
-    /// O(1). Returns option tuple last element and vector without last item  
+    /// O(n). Returns option tuple last element and vector without last item
     member TryUnconj : (PersistentVector<'T> * 'T) option
 
     /// O(log32n). Returns a new vector that contains the given value at the index.
@@ -126,10 +126,10 @@ module PersistentVector =
     ///O(n). Views the given vector as a sequence.
     val inline toSeq  : PersistentVector<'T> ->  seq<'T>
 
-    /// O(1). Returns tuple last element and vector without last item
+    /// O(n). Returns tuple last element and vector without last item
     val inline unconj : PersistentVector<'T> -> PersistentVector<'T> * 'T
 
-    /// O(1). Returns option tuple last element and vector without last item  
+    /// O(n). Returns option tuple last element and vector without last item
     val inline tryUnconj : PersistentVector<'T> -> (PersistentVector<'T> * 'T) option
 
     /// O(log32n). Returns a new vector that contains the given value at the index. 

--- a/src/FSharpx.Collections/RandomAccessList.fsi
+++ b/src/FSharpx.Collections/RandomAccessList.fsi
@@ -4,8 +4,12 @@
 #else
 /// RandomAccessList is an ordered linear structure implementing the List signature 
 /// (head, tail, cons), as well as inspection (lookup) and update (returning a new 
-/// immutable instance) of any element in the structure by index. Ordering is by insertion history.
-/// While PersistentVector<'T> is appending to the end this version prepends ekements to the list.
+/// immutable instance) of any element in the structure by index. Length is O(1). Indexed
+/// lookup or update (returning a new immutable instance of RandomAccessList) of any element
+/// is O(log32n), which is close enough to O(1) as to make no practical difference: a
+/// RandomAccessList containing 4 billion items can lookup or update any item in at most 7
+/// steps. Ordering is by insertion history. While PersistentVector<'T> is appending to the
+/// end this version prepends elements to the list.
 [<Class>]
 type RandomAccessList<'T> =
     interface System.Collections.Generic.IEnumerable<'T>
@@ -17,7 +21,7 @@ type RandomAccessList<'T> =
     /// O(1). Returns true if the random access list has no elements.
     member IsEmpty : bool
 
-    /// O(log32n). Returns random access list element at the index.
+    /// O(1) for all practical purposes; really O(log32n). Returns random access list element at the index.
     member Item : int -> 'T with get
 
     /// O(1). Returns the first element in the random access list. If the random access list is empty it throws an exception.
@@ -29,13 +33,13 @@ type RandomAccessList<'T> =
     /// O(1). Returns the number of items in the random access list.
     member Length : int
          
-    ///O(n). Returns random access list reversed.
+    /// O(n). Returns random access list reversed.
     member Rev : unit -> RandomAccessList<'T>
 
-    /// O(n). Returns a new random access list without the first item. If the collection is empty it throws an exception.
+    /// O(1) for all practical purposes; really O(log32n). Returns a new random access list without the first item. If the collection is empty it throws an exception.
     member Tail : RandomAccessList<'T>
 
-    /// O(n). Returns option random access list without the first item.
+    /// O(1) for all practical purposes; really O(log32n). Returns option random access list without the first item.
     member TryTail : RandomAccessList<'T> option
 
     /// O(1). Returns tuple first element and random access list without first item
@@ -44,10 +48,10 @@ type RandomAccessList<'T> =
     /// O(1). Returns option tuple first element and random access list without first item
     member TryUncons : ('T * RandomAccessList<'T>) option
 
-    /// O(log32n). Returns a new random access list that contains the given value at the index.
+    /// O(1) for all practical purposes; really O(log32n). Returns a new random access list that contains the given value at the index.
     member Update : int * 'T -> RandomAccessList<'T> 
 
-    /// O(log32n). Returns option random access list that contains the given value at the index.
+    /// O(1) for all practical purposes; really O(log32n). Returns option random access list that contains the given value at the index.
     member TryUpdate : int * 'T -> RandomAccessList<'T> option
             
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
@@ -59,7 +63,7 @@ module RandomAccessList =
     /// O(1). Returns a new random access list with the element added at the start.
     val inline cons : 'T -> RandomAccessList<'T> -> RandomAccessList<'T>
 
-    ///O(1). Returns random access list of no elements.
+    /// O(1). Returns random access list of no elements.
     [<GeneralizableValue>]
     val empty<'T> : RandomAccessList<'T>
 
@@ -87,25 +91,25 @@ module RandomAccessList =
     /// O(n). Returns a random access list whose elements are the results of applying the supplied function to each of the elements of a supplied random access list.
     val map : ('T -> 'T1) -> RandomAccessList<'T> -> RandomAccessList<'T1>
 
-    /// O(log32n). Returns the value at the index.
+    /// O(1) for all practical purposes; really O(log32n). Returns the value at the index.
     val inline nth : int -> RandomAccessList<'T> -> 'T
 
-    /// O(log32n). Returns option value at the index. 
+    /// O(1) for all practical purposes; really O(log32n). Returns option value at the index.
     val inline tryNth : int -> RandomAccessList<'T> -> 'T option
  
     /// O(n). Returns a random access list of the seq.
     val ofSeq : seq<'T> -> RandomAccessList<'T>
 
-    ///O(n). Returns new random access list reversed.
+    /// O(n). Returns new random access list reversed.
     val inline rev : RandomAccessList<'T> -> RandomAccessList<'T>
 
-    /// O(n). Returns a new random access list without the first item. If the collection is empty it throws an exception.
+    /// O(1) for all practical purposes; really O(log32n). Returns a new random access list without the first item. If the collection is empty it throws an exception.
     val inline tail : RandomAccessList<'T> -> RandomAccessList<'T>
 
-    /// O(n). Returns option random access list without the first item.
+    /// O(1) for all practical purposes; really O(log32n). Returns option random access list without the first item.
     val inline tryTail : RandomAccessList<'T> -> RandomAccessList<'T> option
 
-    ///O(n). Views the given random access list as a sequence.
+    /// O(n). Views the given random access list as a sequence.
     val inline toSeq  : RandomAccessList<'T> ->  seq<'T>
 
     /// O(1). Returns tuple first element and random access list without first item
@@ -114,9 +118,9 @@ module RandomAccessList =
     /// O(1). Returns option tuple first element and random access list without first item
     val inline tryUncons : RandomAccessList<'T> -> ('T * RandomAccessList<'T>) option
 
-    /// O(log32n). Returns a new random access list that contains the given value at the index. 
+    /// O(1) for all practical purposes; really O(log32n). Returns a new random access list that contains the given value at the index.
     val inline update : int -> 'T -> RandomAccessList<'T> -> RandomAccessList<'T>
 
-    /// O(log32n). Returns option random access list that contains the given value at the index. 
+    /// O(1) for all practical purposes; really O(log32n). Returns option random access list that contains the given value at the index.
     val inline tryUpdate : int -> 'T -> RandomAccessList<'T> -> RandomAccessList<'T> option
 #endif

--- a/src/FSharpx.Collections/RandomAccessList.fsi
+++ b/src/FSharpx.Collections/RandomAccessList.fsi
@@ -11,7 +11,7 @@ type RandomAccessList<'T> =
     interface System.Collections.Generic.IEnumerable<'T>
     interface System.Collections.IEnumerable
 
-    /// O(1). Returns a new random access list with the element added at the end.
+    /// O(1). Returns a new random access list with the element added at the start.
     member Cons : 'T -> RandomAccessList<'T>
 
     /// O(1). Returns true if the random access list has no elements.
@@ -20,10 +20,10 @@ type RandomAccessList<'T> =
     /// O(log32n). Returns random access list element at the index.
     member Item : int -> 'T with get
 
-    /// O(1). Returns the last element in the random access list. If the random access list is empty it throws an exception.
+    /// O(1). Returns the first element in the random access list. If the random access list is empty it throws an exception.
     member Head : 'T
 
-    /// O(1). Returns option last element in the random access list.
+    /// O(1). Returns option first element in the random access list.
     member TryHead : 'T option
 
     /// O(1). Returns the number of items in the random access list.
@@ -32,16 +32,16 @@ type RandomAccessList<'T> =
     ///O(n). Returns random access list reversed.
     member Rev : unit -> RandomAccessList<'T>
 
-    /// O(n). Returns a new random access list without the last item. If the collection is empty it throws an exception.
+    /// O(n). Returns a new random access list without the first item. If the collection is empty it throws an exception.
     member Tail : RandomAccessList<'T>
 
-    /// O(n). Returns option random access list without the last item.
+    /// O(n). Returns option random access list without the first item.
     member TryTail : RandomAccessList<'T> option
 
-    /// O(1). Returns tuple last element and random access list without last item  
+    /// O(1). Returns tuple first element and random access list without first item
     member Uncons : 'T * RandomAccessList<'T>
 
-    /// O(1). Returns option tuple last element and random access list without last item  
+    /// O(1). Returns option tuple first element and random access list without first item
     member TryUncons : ('T * RandomAccessList<'T>) option
 
     /// O(log32n). Returns a new random access list that contains the given value at the index.
@@ -55,8 +55,8 @@ type RandomAccessList<'T> =
 module RandomAccessList = 
     //pattern discriminators (active pattern)
     val (|Cons|Nil|) : RandomAccessList<'T> ->  Choice<('T * RandomAccessList<'T> ),unit>
-    
-    /// O(1). Returns a new random access list with the element added at the end.   
+
+    /// O(1). Returns a new random access list with the element added at the start.
     val inline cons : 'T -> RandomAccessList<'T> -> RandomAccessList<'T>
 
     ///O(1). Returns random access list of no elements.
@@ -75,10 +75,10 @@ module RandomAccessList =
     /// O(1). Returns true if the random access list has no elements.
     val inline isEmpty : RandomAccessList<'T> -> bool
 
-    /// O(1). Returns the last element in the random access list. If the random access list is empty it throws an exception.
+    /// O(1). Returns the first element in the random access list. If the random access list is empty it throws an exception.
     val inline head : RandomAccessList<'T> -> 'T
 
-    /// O(1). Returns option last element in the random access list.
+    /// O(1). Returns option first element in the random access list.
     val inline tryHead : RandomAccessList<'T> -> 'T option
 
     /// O(1). Returns the number of items in the random access list.
@@ -99,19 +99,19 @@ module RandomAccessList =
     ///O(n). Returns new random access list reversed.
     val inline rev : RandomAccessList<'T> -> RandomAccessList<'T>
 
-    /// O(n). Returns a new random access list without the last item. If the collection is empty it throws an exception.
+    /// O(n). Returns a new random access list without the first item. If the collection is empty it throws an exception.
     val inline tail : RandomAccessList<'T> -> RandomAccessList<'T>
 
-    /// O(n). Returns option random access list without the last item.
+    /// O(n). Returns option random access list without the first item.
     val inline tryTail : RandomAccessList<'T> -> RandomAccessList<'T> option
 
     ///O(n). Views the given random access list as a sequence.
     val inline toSeq  : RandomAccessList<'T> ->  seq<'T>
 
-    /// O(1). Returns tuple last element and random access list without last item
+    /// O(1). Returns tuple first element and random access list without first item
     val inline uncons : RandomAccessList<'T> -> 'T * RandomAccessList<'T>
 
-    /// O(1). Returns option tuple last element and random access list without last item  
+    /// O(1). Returns option tuple first element and random access list without first item
     val inline tryUncons : RandomAccessList<'T> -> ('T * RandomAccessList<'T>) option
 
     /// O(log32n). Returns a new random access list that contains the given value at the index. 

--- a/src/FSharpx.Collections/ResizeArray.fsi
+++ b/src/FSharpx.Collections/ResizeArray.fsi
@@ -33,32 +33,32 @@ module ResizeArray =
     /// Create an array by calling the given generator on each index.
     val init: int -> (int -> 'T) -> ResizeArray<'T>
 
-    ///Build a new array that contains the elements of the first array followed by the elements of the second array
+    /// Build a new array that contains the elements of the first array followed by the elements of the second array
     val append: ResizeArray<'T> -> ResizeArray<'T> -> ResizeArray<'T>
 
-    ///Build a new array that contains the elements of each of the given list of arrays
+    /// Build a new array that contains the elements of each of the given list of arrays
     val concat: seq<ResizeArray<'T>> -> ResizeArray<'T>
 
-    ///Build a new array that contains the given subrange specified by
-    ///starting index and length.
+    /// Build a new array that contains the given subrange specified by
+    /// starting index and length.
     val sub: ResizeArray<'T> -> int -> int -> ResizeArray<'T>
 
-    ///Build a new array that contains the elements of the given array
+    /// Build a new array that contains the elements of the given array
     val copy: ResizeArray<'T> -> ResizeArray<'T>
 
-    ///Fill a range of the collection with the given element
+    /// Fill a range of the collection with the given element
     val fill: ResizeArray<'T> -> int -> int -> 'T -> unit
 
-    ///Read a range of elements from the first array and write them into the second.
+    /// Read a range of elements from the first array and write them into the second.
     val blit: ResizeArray<'T> -> int -> ResizeArray<'T> -> int -> int -> unit
 
-    ///Build a list from the given array
+    /// Build a list from the given array
     val toList: ResizeArray<'T> -> 'T list
 
-    ///Build an array from the given list
+    /// Build an array from the given list
     val ofList: 'T list -> ResizeArray<'T>
 
-    ///Build and array from the given seq
+    /// Build and array from the given seq
     val ofSeq : 'T seq -> ResizeArray<'T>
 
     /// Apply a function to each element of the collection, threading an accumulator argument
@@ -71,30 +71,30 @@ module ResizeArray =
     /// computes <c>f i0 (...(f iN s))</c>.
     val foldBack: ('T -> 'State -> 'State) -> ResizeArray<'T> -> 'State -> 'State
 
-    ///Apply the given function to each element of the array. 
+    /// Apply the given function to each element of the array. 
     val iter: ('T -> unit) -> ResizeArray<'T> -> unit
 
-    ///Build a new array whose elements are the results of applying the given function
-    ///to each of the elements of the array.
+    /// Build a new array whose elements are the results of applying the given function
+    /// to each of the elements of the array.
     val map: ('T -> 'U) -> ResizeArray<'T> -> ResizeArray<'U>
 
-    ///Apply the given function to two arrays simultaneously. The
-    ///two arrays must have the same lengths, otherwise an Invalid_argument exception is
-    ///raised.
+    /// Apply the given function to two arrays simultaneously. The
+    /// two arrays must have the same lengths, otherwise an Invalid_argument exception is
+    /// raised.
     val iter2: ('T1 -> 'T2 -> unit) -> ResizeArray<'T1> -> ResizeArray<'T2> -> unit
 
-    ///Build a new collection whose elements are the results of applying the given function
-    ///to the corresponding elements of the two collections pairwise.  The two input
-    ///arrays must have the same lengths.
+    /// Build a new collection whose elements are the results of applying the given function
+    /// to the corresponding elements of the two collections pairwise.  The two input
+    /// arrays must have the same lengths.
     val map2: ('T1 -> 'T2 -> 'U) -> ResizeArray<'T1> -> ResizeArray<'T2> -> ResizeArray<'U>
 
-    ///Apply the given function to each element of the array.  The integer passed to the
-    ///function indicates the index of element.
+    /// Apply the given function to each element of the array.  The integer passed to the
+    /// function indicates the index of element.
     val iteri: (int -> 'T -> unit) -> ResizeArray<'T> -> unit
 
-    ///Build a new array whose elements are the results of applying the given function
-    ///to each of the elements of the array. The integer index passed to the
-    ///function indicates the index of element being transformed.
+    /// Build a new array whose elements are the results of applying the given function
+    /// to each of the elements of the array. The integer index passed to the
+    /// function indicates the index of element being transformed.
     val mapi: (int -> 'T -> 'U) -> ResizeArray<'T> -> ResizeArray<'U>
 
     /// Test if any element of the array satisfies the given predicate.
@@ -107,33 +107,33 @@ module ResizeArray =
     /// then computes <c>p i0 && ... && p iN</c>.
     val forall: ('T -> bool) -> ResizeArray<'T> -> bool
 
-    ///Return a new collection containing only the elements of the collection
-    ///for which the given predicate returns <c>true</c>
+    /// Return a new collection containing only the elements of the collection
+    /// for which the given predicate returns <c>true</c>
     val filter: ('T -> bool) -> ResizeArray<'T> -> ResizeArray<'T>
 
-    ///Split the collection into two collections, containing the 
-    ///elements for which the given predicate returns <c>true</c> and <c>false</c>
-    ///respectively 
+    /// Split the collection into two collections, containing the 
+    /// elements for which the given predicate returns <c>true</c> and <c>false</c>
+    /// respectively 
     val partition: ('T -> bool) -> ResizeArray<'T> -> ResizeArray<'T> * ResizeArray<'T>
 
-    ///Apply the given function to each element of the array. Return
-    ///the array comprised of the results "x" for each element where
-    ///the function returns Some(x)
+    /// Apply the given function to each element of the array. Return
+    /// the array comprised of the results "x" for each element where
+    /// the function returns Some(x)
     val choose: ('T -> 'U option) -> ResizeArray<'T> -> ResizeArray<'U>
 
-    ///Return the first element for which the given function returns <c>true</c>.
-    ///Raise <c>KeyNotFoundException</c> if no such element exists.
+    /// Return the first element for which the given function returns <c>true</c>.
+    /// Raise <c>KeyNotFoundException</c> if no such element exists.
     val find: ('T -> bool) -> ResizeArray<'T> -> 'T
 
-    ///Return the first element for which the given function returns <c>true</c>.
-    ///Return None if no such element exists.
+    /// Return the first element for which the given function returns <c>true</c>.
+    /// Return None if no such element exists.
     val tryFind: ('T -> bool) -> ResizeArray<'T> -> 'T option
 
-    ///Apply the given function to successive elements, returning the first
-    ///result where function returns "Some(x)" for some x.
+    /// Apply the given function to successive elements, returning the first
+    /// result where function returns "Some(x)" for some x.
     val tryPick: ('T -> 'U option) -> ResizeArray<'T> -> 'U option
 
-    ///Return a new array with the elements in reverse order
+    /// Return a new array with the elements in reverse order
     val rev: ResizeArray<'T> -> ResizeArray<'T>
 
     /// Sort the elements using the given comparison function


### PR DESCRIPTION
Fix a few documentation mistakes:

* RandomAccessList.Cons doesn't append to the list, it prepends.
* RandomAccessList.Head and .TryHead return first element, not last.
* RandomAccessList.Tail and .TryTail strip first element, not last.
* RandomAccessList.Uncons strips first element, not last.
* PersistentVector.Unconj and .TryUnconj are O(n), not O(1).

I also made some minor whitespace edits (so that comments would look consistent within one file) in a second commit, but I can revert those if you'd prefer not to have whitespace-only edits. I didn't try to make the comment style consistent between files, just make each file internally consistent.
