### PR TITLE
Improve RandomAccessList API with some functions from PersistentVector

### DIFF
--- a/src/FSharpx.Collections/PersistentVector.fs
+++ b/src/FSharpx.Collections/PersistentVector.fs
@@ -446,7 +446,7 @@ module PersistentVector =
 
     let inline tryUpdate i (x : 'T) (vector : PersistentVector<'T>) = vector.TryUpdate(i, x)
 
-    let inline tryUpdateNth i  j (x : 'T) (vector : PersistentVector<PersistentVector<'T>>) = 
+    let inline tryUpdateNth i j (x : 'T) (vector : PersistentVector<PersistentVector<'T>>) =
         if i >= 0 && i < vector.Length && j >= 0 && j < vector.[i].Length
         then Some(updateNth i j x vector)
         else None

--- a/src/FSharpx.Collections/PersistentVector.fsi
+++ b/src/FSharpx.Collections/PersistentVector.fsi
@@ -107,7 +107,7 @@ module PersistentVector =
     /// O(1) for all practical purposes; really O(log32n). Returns the value at the index. If the index is out of bounds it throws an exception.
     val inline nth : int -> PersistentVector<'T> -> 'T
 
-    /// O(log32(m,n)). Returns the value at the  outer index, inner index. If either index is out of bounds it throws an exception.
+    /// O(log32(m,n)). Returns the value at the outer index, inner index. If either index is out of bounds it throws an exception.
     val inline nthNth : int -> int -> PersistentVector<PersistentVector<'T>> -> 'T
  
     /// O(1) for all practical purposes; really O(log32n). Returns option value at the index.

--- a/src/FSharpx.Collections/RandomAccessList.fs
+++ b/src/FSharpx.Collections/RandomAccessList.fs
@@ -381,10 +381,19 @@ module RandomAccessList =
     let inline tryNth i (randomAccessList :'T RandomAccessList) =
         if i >= 0 && i < randomAccessList.Length then Some(randomAccessList.[i])
         else None
- 
+
+    let inline nthNth i j (randomAccessList :'T RandomAccessList RandomAccessList) : 'T = randomAccessList.[i] |> nth j
+
+    let inline tryNthNth i j (randomAccessList :'T RandomAccessList RandomAccessList) =
+        match tryNth i randomAccessList with
+        | Some v' -> tryNth j v'
+        | None -> None
+
     let ofSeq (items : 'T seq) = RandomAccessList.ofSeq items 
 
     let inline rev (randomAccessList :'T RandomAccessList) = randomAccessList.Rev()
+
+    let inline singleton (x : 'T) = empty |> cons x
 
     let inline tail (randomAccessList :'T RandomAccessList) = randomAccessList.Tail
 
@@ -398,6 +407,13 @@ module RandomAccessList =
 
     let inline update i (x : 'T) (randomAccessList : 'T RandomAccessList) = randomAccessList.Update(i, x)
 
+    let inline updateNth i j (x : 'T) (randomAccessList : 'T RandomAccessList RandomAccessList) : 'T RandomAccessList RandomAccessList = randomAccessList.Update(i, (randomAccessList.[i].Update(j, x)))
+
     let inline tryUpdate i (x : 'T) (randomAccessList : 'T RandomAccessList) = randomAccessList.TryUpdate(i, x)
+
+    let inline tryUpdateNth i  j (x : 'T) (randomAccessList : 'T RandomAccessList RandomAccessList) =
+        if i >= 0 && i < randomAccessList.Length && j >= 0 && j < randomAccessList.[i].Length
+        then Some(updateNth i j x randomAccessList)
+        else None
 
 #endif

--- a/src/FSharpx.Collections/RandomAccessList.fs
+++ b/src/FSharpx.Collections/RandomAccessList.fs
@@ -337,7 +337,15 @@ and RandomAccessList<'T> (count,shift:int,root:NodeR,tail:obj[])  =
 module RandomAccessList = 
     //pattern discriminators  (active pattern)
     let (|Cons|Nil|) (v : RandomAccessList<'T>) = match v.TryUncons with Some(a,b) -> Cons(a,b) | None -> Nil
-     
+
+    let append (listA : RandomAccessList<'T>) (listB : RandomAccessList<'T>) =
+        let mutable ret = TransientVect()
+        for i in (listB.Length - 1) .. -1 .. 0 do
+            ret <- ret.conj listB.[i]
+        for i in (listA.Length - 1) .. -1 .. 0 do
+            ret <- ret.conj listA.[i]
+        ret.persistent()
+
     let inline cons (x : 'T) (randomAccessList : 'T RandomAccessList) = randomAccessList.Cons x
 
     let empty<'T> = RandomAccessList.Empty() :> RandomAccessList<'T>
@@ -411,9 +419,22 @@ module RandomAccessList =
 
     let inline tryUpdate i (x : 'T) (randomAccessList : 'T RandomAccessList) = randomAccessList.TryUpdate(i, x)
 
-    let inline tryUpdateNth i  j (x : 'T) (randomAccessList : 'T RandomAccessList RandomAccessList) =
+    let inline tryUpdateNth i j (x : 'T) (randomAccessList : 'T RandomAccessList RandomAccessList) =
         if i >= 0 && i < randomAccessList.Length && j >= 0 && j < randomAccessList.[i].Length
         then Some(updateNth i j x randomAccessList)
         else None
 
+    let inline windowFun windowLength =
+        fun t (v : RandomAccessList<RandomAccessList<'T>>) ->
+        if v.Head.Length = windowLength
+        then
+            v
+            |> cons (empty.Cons(t))
+        else
+            tail v
+            |> cons (head v |> cons t)
+
+    let inline windowSeq windowLength (items: 'T seq) =
+        if windowLength < 1 then invalidArg "windowLength" "length is less than 1"
+        else (Seq.foldBack (windowFun windowLength) items (empty.Cons empty<'T>)) (*Seq.fold (windowFun windowLength) (empty.Cons empty<'T>) items*) // TODO: Check if this should be foldBack due to inversion effects of prepending
 #endif

--- a/src/FSharpx.Collections/RandomAccessList.fsi
+++ b/src/FSharpx.Collections/RandomAccessList.fsi
@@ -97,11 +97,20 @@ module RandomAccessList =
     /// O(1) for all practical purposes; really O(log32n). Returns option value at the index.
     val inline tryNth : int -> RandomAccessList<'T> -> 'T option
  
+    /// O(log32(m,n)). Returns the value at the outer index, inner index. If either index is out of bounds it throws an exception.
+    val inline nthNth : int -> int -> RandomAccessList<RandomAccessList<'T>> -> 'T
+
+    /// O(log32(m,n)). Returns option value at the indices.
+    val inline tryNthNth : int -> int -> RandomAccessList<RandomAccessList<'T>> -> 'T option
+
     /// O(n). Returns a random access list of the seq.
     val ofSeq : seq<'T> -> RandomAccessList<'T>
 
     /// O(n). Returns new random access list reversed.
     val inline rev : RandomAccessList<'T> -> RandomAccessList<'T>
+
+    /// O(1). Returns a new random access list of one element.
+    val inline singleton : 'T -> RandomAccessList<'T>
 
     /// O(1) for all practical purposes; really O(log32n). Returns a new random access list without the first item. If the collection is empty it throws an exception.
     val inline tail : RandomAccessList<'T> -> RandomAccessList<'T>
@@ -121,6 +130,12 @@ module RandomAccessList =
     /// O(1) for all practical purposes; really O(log32n). Returns a new random access list that contains the given value at the index.
     val inline update : int -> 'T -> RandomAccessList<'T> -> RandomAccessList<'T>
 
+    /// O(log32(m,n)). Returns a new random access list of random access lists that contains the given value at the indices.
+    val inline updateNth : int -> int -> 'T -> RandomAccessList<RandomAccessList<'T>> -> RandomAccessList<RandomAccessList<'T>>
+
     /// O(1) for all practical purposes; really O(log32n). Returns option random access list that contains the given value at the index.
     val inline tryUpdate : int -> 'T -> RandomAccessList<'T> -> RandomAccessList<'T> option
+
+    /// O(log32(m,n)). Returns option random access list that contains the given value at the indices.
+    val inline tryUpdateNth : int -> int -> 'T -> RandomAccessList<RandomAccessList<'T>> -> RandomAccessList<RandomAccessList<'T>> option
 #endif

--- a/src/FSharpx.Collections/RandomAccessList.fsi
+++ b/src/FSharpx.Collections/RandomAccessList.fsi
@@ -60,6 +60,9 @@ module RandomAccessList =
     //pattern discriminators (active pattern)
     val (|Cons|Nil|) : RandomAccessList<'T> ->  Choice<('T * RandomAccessList<'T> ),unit>
 
+    /// O(n). Returns a new random access list with the elements of the second random access list added at the end.
+    val append : RandomAccessList<'T> -> RandomAccessList<'T> -> RandomAccessList<'T>
+
     /// O(1). Returns a new random access list with the element added at the start.
     val inline cons : 'T -> RandomAccessList<'T> -> RandomAccessList<'T>
 
@@ -138,4 +141,7 @@ module RandomAccessList =
 
     /// O(log32(m,n)). Returns option random access list that contains the given value at the indices.
     val inline tryUpdateNth : int -> int -> 'T -> RandomAccessList<RandomAccessList<'T>> -> RandomAccessList<RandomAccessList<'T>> option
+
+    /// O(n). Returns a random access list of random access lists of given length from the seq. Result may be a jagged random access list.
+    val inline windowSeq : int  -> seq<'T> -> RandomAccessList<RandomAccessList<'T>>
 #endif


### PR DESCRIPTION
These are the easy functions, which aren't dependent on order of insertion. Functions like append and windowSeq will be harder, so wait until later to add those. But take the low-hanging fruit now.

Note that I have not yet written unit tests for these. These functions are straightforward, and I copied the implementations from PersistentVector and just changed the type signatures (and parameter names), so I doubt that there are any errors. So feel free to merge this now if you want; but if you want to hold off on merging this PR until I can write unit tests for these new functions, I can do that within the next couple of days.