### PR TITLE
Distinct and DistinctBy functions

### DIFF
--- a/src/FSharpx.Collections/ResizeArray.fs
+++ b/src/FSharpx.Collections/ResizeArray.fs
@@ -7,7 +7,6 @@ namespace Microsoft.FSharp.Collections
 
 open Microsoft.FSharp.Core.OptimizedClosures
 
-
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module ResizeArray =
 
@@ -322,6 +321,24 @@ module ResizeArray =
             res1.Add(x)
             res2.Add(y)
         res1,res2
+
+    
+
+    let distinctBy keyf (array:ResizeArray<_>) =
+        let temp = ResizeArray()
+        let hashSet = System.Collections.Generic.HashSet(HashIdentity.Structural)
+        for v in array do
+            if hashSet.Add(keyf v) then
+                temp.Add(v)
+        temp
+
+    let distinct (array:ResizeArray<_>) =
+        let temp = ResizeArray()
+        let hashSet = System.Collections.Generic.HashSet(HashIdentity.Structural)
+        for v in array do
+            if hashSet.Add(v) then
+                temp.Add(v)
+        temp
 
     let combine arr1 arr2 = zip arr1 arr2
     let split arr = unzip arr

--- a/src/FSharpx.Collections/ResizeArray.fsi
+++ b/src/FSharpx.Collections/ResizeArray.fsi
@@ -227,3 +227,13 @@ module ResizeArray =
 
     /// Split an array of pairs into two arrays
     val unzip : ResizeArray<'T1 * 'T2> -> ResizeArray<'T1> * ResizeArray<'T2>
+
+    /// Returns an array that contains no duplicate entries according to the 
+    /// generic hash and equality comparisons on the keys returned by the given key-generating function.
+    /// If an element occurs multiple times in the array then the later occurrences are discarded.
+    val distinctBy: ('T -> 'Key) -> ResizeArray<'T> -> ResizeArray<'T> when 'Key : equality
+
+    /// Returns an array that contains no duplicate entries according to generic hash and
+    /// equality comparisons on the entries.
+    /// If an element occurs multiple times in the array then the later occurrences are discarded.
+    val distinct: ResizeArray<'T> -> ResizeArray<'T> when 'T : equality

--- a/tests/FSharpx.Collections.Tests/ColllectionTests.fs
+++ b/tests/FSharpx.Collections.Tests/ColllectionTests.fs
@@ -9,6 +9,7 @@ type public ResizeArrayTests() =
   
     [<Test>]
     member this.BasicTests() = 
+        let rng = System.Random()
         let ra = ResizeArray.ofList
         let (=?) a b = ResizeArray.toList a = b
 
@@ -193,3 +194,9 @@ type public ResizeArrayTests() =
 
         test "ra_concat concat"
             (ResizeArray.concat (ra [ra [1; 2]; ra [3]; ra [4; 5; 6;]; ra []; ra [7]]) =? (ResizeArray.concat (Seq.ofList[ra [1; 2]; ra [3]; ra [4; 5; 6;]; ra []; ra [7]]) |> List.ofSeq))
+
+        test "ra_distinct a"
+            (let ar = [for i=1 to 100 do yield rng.Next(0,10)] in (ar |> Seq.distinct |> Seq.toArray) = (ar |> ra |> ResizeArray.distinct |> ResizeArray.toArray))
+
+        test "ra_distinctBy a"
+            (let ar = [for i=1 to 100 do yield rng.Next(0,10),rng.Next(0,10)] in (ar |> Seq.distinctBy(fun (x,_) -> x) |> Seq.toArray) = (ar |> ra |> ResizeArray.distinctBy(fun (x,_) -> x) |> ResizeArray.toArray))


### PR DESCRIPTION
A small addition to the Fsharpx.Collections library. They are based of the Fsharp core collections Array functions of the same name and their source is nearly identical. They do not require a null check unlike the Array functions.

Now that I know that HashSet is used under the hood, I feel no need to actually use these functions.

I deliberated whether or not to write tests for the two functions, but they are simple enough that there is not much point in it. I'll do it if that is recommended though.