### PR TITLE
Faster NonEmptyList implementation

### DIFF
--- a/tests/FSharpx.Collections.Experimental.Tests/NonEmptyListTests.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/NonEmptyListTests.fs
@@ -105,9 +105,14 @@ let ``last is last and never fails``() =
 
 [<Test>]
 let ``append has combined length``() =
-    fsCheck <| fun a b ->
-        let c = NonEmptyList.append a b
-        c.Length = a.Length + b.Length
+    fsCheck <| fun (a: _ list) (b: _ list) ->
+        if a.IsEmpty || b.IsEmpty then
+            // we don't test non-empty lists here.
+            true
+        else
+            let neA = NonEmptyList.create a.Head a.Tail
+            let neB = NonEmptyList.create b.Head b.Tail
+            (NonEmptyList.append neA neB).Length = neA.Length + neB.Length
 
 [<Test>]
 let reduce() =


### PR DESCRIPTION
This PR offers an alternative representation for the NonEmptyList using an opaque record type.

This greatly simplifies the code, and has significantly faster iteration performance via the seq interface.

For the benchmark, I used the following code:
```fsharp
[<EntryPoint>]
let main _ = 
    Thread.CurrentThread.Priority <- ThreadPriority.Highest
    let sw = new Stopwatch()
    let list = NonEmptyList.create 0 [1..10000000]
    let benchToSeq() = 
        sw.Start()
        list |> Seq.iter ignore |> ignore
        let time = sw.ElapsedMilliseconds
        sw.Reset()
        time

    [0..10]
    |> List.map (fun _ -> benchToSeq())
    |> List.tail // skip the warmup.
    |> List.reduce (+)
    |> (fun v -> v / 10L)
    |> printfn "Out of 10 runs, the average time was: %dms"
    Console.Read() |> ignore
    0
```

Compiled under Release on Net 4.6.1, the results were:
**Old:** `Out of 10 runs, the average time was: 154ms`
**New:** `Out of 10 runs, the average time was: 77ms`

Note: it seems as though FsCheck append sizing property is somehow breaking due to the opaque type. I'd appreciate any help on getting that test to pass.