### PR TITLE
NonEmptyList Collect has poor performance

### DIFF
--- a/src/FSharpx.Collections/NonEmptyList.fs
+++ b/src/FSharpx.Collections/NonEmptyList.fs
@@ -4,8 +4,7 @@ open System
 open System.Collections
 open System.Collections.Generic
 open System.Runtime.CompilerServices
-open FSharpx
- 
+
 type NonEmptyList<'T> = 
     private { List: 'T list }
 
@@ -91,9 +90,6 @@ module NonEmptyList =
     let reduce reduction list =
         List.reduce reduction list.List
 
-    [<CompiledName("Last")>]
-    let last list =
-        List.last list.List
 
     [<CompiledName("Reverse")>]
     [<Extension>]
@@ -101,8 +97,8 @@ module NonEmptyList =
         { List = List.rev list.List}
 
     [<CompiledName("SelectMany")>]
-    let collect mapping list =
-        List.fold (fun s e -> mapping e |> append s) (mapping (head list)) (tail list)
+    let collect (mapping:'a -> NonEmptyList<'b>) (list:NonEmptyList<'a>) =
+        list.List |> List.collect (fun x -> (mapping x).List) |> ofList
 
     [<CompiledName("Zip")>]
     let zip list1 list2 =

--- a/src/FSharpx.Collections/NonEmptyList.fs
+++ b/src/FSharpx.Collections/NonEmptyList.fs
@@ -90,6 +90,9 @@ module NonEmptyList =
     let reduce reduction list =
         List.reduce reduction list.List
 
+    [<CompiledName("Last")>]
+    let last list =
+        List.last list.List
 
     [<CompiledName("Reverse")>]
     [<Extension>]


### PR DESCRIPTION
Using the following test in FSI

let nonEmpty = NonEmptyList.ofList [ for _ in 0 .. 1000 -> NonEmptyList.ofList [ for i in 0 .. 1000 -> i ]  ];;

#time
nonEmpty|> NonEmptyList.collect id;;

Real: **00:01:09.289**, CPU: **00:01:13.750**, GC gen0: **1409**, gen1: **1274**, gen2: **241**

The issue seems to be the append call, which is a probematic case for singly linked lists (quadratic growth)

After the code-change in this PR 

Real: **00:00:00.121**, CPU: **00:00:00.125**, GC gen0: **4**, gen1: **3**, gen2: **1**

Special care has been taken to ensure the public contract is unchanged.
`(mapping:'a -> NonEmptyList<'b>) (list:NonEmptyList<'a>) : NonEmptyList<'b>`

There doesn't seem to be any existing tests for this functionality - I can add some as part of this PR if required. 

Intermediate allocations could probably be further reduced, but I think that this change is significant enough improvement to warrant consideration. 