### PR TITLE
Remove redundant open statement

### DIFF
--- a/src/FSharpx.Collections/RandomAccessList.fs
+++ b/src/FSharpx.Collections/RandomAccessList.fs
@@ -11,7 +11,6 @@ module internal Literals2 =
     [<Literal>]
     let internal blockIndexMask = 0x01f
 
-open FSharpx
 open System.Threading
 #if FX_NO_THREAD
 #else


### PR DESCRIPTION
`RandomAccessList.fs` does not depend on anything else of the library. By removing this redundant open statement, the file can be used as a Paket GitHub dependency (which is the only scenario of using it from .NET Standard, see #77)