### PR TITLE
Convert RoseTree children to seq before getting hash code

### DIFF
--- a/src/FSharpx.Collections.Experimental/RoseTree.fs
+++ b/src/FSharpx.Collections.Experimental/RoseTree.fs
@@ -20,7 +20,7 @@ type RoseTree<[<EqualityConditionalOn>] 'T> =
     override x.GetHashCode() = 
         391
         + (box x.Root).GetHashCode() * 23
-        + x.Children.GetHashCode()
+        + (x.Children :> _ seq).GetHashCode()
 
     interface IEquatable<RoseTree<'T>> with
         member x.Equals y = 


### PR DESCRIPTION
The children are a lazy list, which means the standard GetHashCode() won't provide structural equality.

I noticed this issue whilst playing around with trees under .NET Core, because it appears in .NET Core
it is a compile error to use GetHashCode() on an object with the NoEquality attribute.
