### PR TITLE
Run tests with a single runTestsInAssembly call.

### DIFF
--- a/tests/FSharpx.Collections.Experimental.Tests/RoseTreeTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/RoseTreeTest.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharpx.Collections.Experimental.Tests
+namespace FSharpx.Collections.Experimental.Tests
 
 open FsCheck
 open FSharpx.Collections
@@ -144,7 +144,7 @@ module RoseTreeTest =
         let inline (>>=) m f = RoseTree.bind f m
         let ret = RoseTree.singleton
 
-        testList "Experimental RoseTree propeerties" [
+        testList "Experimental RoseTree properties" [
 
             ptestPropertyWithConfig config10k "RoseTree functor laws: preserves identity" 
                 (Prop.forAll (roseTree()) <|

--- a/tests/FSharpx.Collections.Experimental.Tests/RunTests.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/RunTests.fs
@@ -1,83 +1,9 @@
 namespace FSharpx.Collections.Experimental.Tests
 
 open Expecto
+open Expecto.Impl
 
 module RunTests =
 
     [<EntryPoint>]
-    let main args =
-
-        Tests.runTestsWithArgs defaultConfig args AltBinaryRandomAccessListTest.testAltBinaryRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BankersDequeTest.testBankersDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BatchDequeTest.testBatchDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinaryRandomAccessListTest.testBinaryRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinaryRoseTreeTest.testBinaryRoseTree |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinaryTreeZipperTest.testBinaryTreeZipper |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinomialHeapTest.testBinomialHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args BinomialHeapTest.propertyBinomialHeap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BKTreeTest.testBKTree |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BlockResizeArrayTest.testBlockResizeArray |> ignore
-        Tests.runTestsWithArgs defaultConfig args BlockResizeArrayTest.testBlockResizeArrayPropeerties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BootstrappedQueueTest.testBootstrappedQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BottomUpMergeSortTest.testBottomUpMergeSort |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DequeTest.testDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DListTest.testDList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args EagerRoseTreeTest.testEagerRoseTree |> ignore
-        Tests.runTestsWithArgs defaultConfig args EagerRoseTreeTest.testEagerRoseTreePropeerties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args EditDistanceTest.testEditDistance |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args FileSystemZipperTest.testFileSystemZipper |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args FlatListTest.testFlatList |> ignore
-        Tests.runTestsWithArgs defaultConfig args FlatListTest.testFlatListProperties|> ignore
-
-        Tests.runTestsWithArgs defaultConfig args HeapPriorityQueueTest.testHeapPriorityQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ImplicitQueueTest.testImplicitQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args IndexedRoseTreeTest.testIndexedRoseTree |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args IntMapTest.testIntMap |> ignore
-        Tests.runTestsWithArgs defaultConfig args IntMapTest.testIntMapProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args IQueueTest.testIQueue |> ignore
-        Tests.runTestsWithArgs defaultConfig args IQueueTest.testIQueueProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args LeftistHeapTest.testLeftistHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args LeftistHeapTest.testLeftistHeapProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ListZipperTest.testListZipper |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PairingHeapTest.testPairingHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args PairingHeapTest.testPairingHeapProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RealTimeDequeTest.testRealTimeDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RealTimeQueueTest.testRealTimeQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RingBufferTest.testRingBuffer |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RoseTreeTest.testRoseTree |> ignore
-        Tests.runTestsWithArgs defaultConfig args RoseTreeTest.testRoseTreeProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args SkewBinaryRandomAccessListTest.testSkewBinaryRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args SkewBinomialHeapTest.testSkewBinomialHeap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args TimeSeriesTest.testTimeSeries |> ignore
-    
-        0
+    let main args = runTestsInAssembly ExpectoConfig.defaultConfig args

--- a/tests/FSharpx.Collections.Tests/ListExtensionsTest.fs
+++ b/tests/FSharpx.Collections.Tests/ListExtensionsTest.fs
@@ -7,6 +7,7 @@ open Expecto.Flip
 
 module ListExtensionsTests =
 
+    [<Tests>]
     let testListExtensions =
         testList "ListExtensions" [
 
@@ -71,6 +72,7 @@ module ListExtensionsTests =
                 Expect.equal "transpose" expected (a |> List.transpose) }
         ]
 
+    [<Tests>]
     let propertyTestListExtensions =
         let fill (total:int) (elem:'a) (list:'a list) = 
             let padded = List.fill total elem list 

--- a/tests/FSharpx.Collections.Tests/NameValueCollectionTests.fs
+++ b/tests/FSharpx.Collections.Tests/NameValueCollectionTests.fs
@@ -9,6 +9,7 @@ open Expecto.Flip
 
 module NameValueCollectionTests =
 
+    [<Tests>]
     let testNameValueCollection =
 
         let assertKeyIs (l: ILookup<_,_>) a key = 

--- a/tests/FSharpx.Collections.Tests/PersistentHashMapTest.fs
+++ b/tests/FSharpx.Collections.Tests/PersistentHashMapTest.fs
@@ -7,6 +7,7 @@ open Expecto
 open Expecto.Flip
 
 module PersistentHashMapTests =
+    [<Tests>]
     let testPersistentHashMap =
 
         testList "PersistentHashMap" [

--- a/tests/FSharpx.Collections.Tests/PersistentVectorTest.fs
+++ b/tests/FSharpx.Collections.Tests/PersistentVectorTest.fs
@@ -6,6 +6,7 @@ open Expecto
 open Expecto.Flip
 
 module PersistentVectorTests =
+    [<Tests>]
     let testPersistentVector =
 
         testList "PersistentVector" [

--- a/tests/FSharpx.Collections.Tests/PriorityQueueTest.fs
+++ b/tests/FSharpx.Collections.Tests/PriorityQueueTest.fs
@@ -5,6 +5,7 @@ open Expecto
 open Expecto.Flip
 
 module PriorityQueueTests =
+    [<Tests>]
     let testPriorityQueue =
 
         testList "PriorityQueue" [

--- a/tests/FSharpx.Collections.Tests/QueueTest.fs
+++ b/tests/FSharpx.Collections.Tests/QueueTest.fs
@@ -9,6 +9,7 @@ open Expecto.Flip
 module QueueTests =
     let emptyQueue = Queue.empty
 
+    [<Tests>]
     let testQueue =
 
         testList "Queue" [

--- a/tests/FSharpx.Collections.Tests/RandomAccessListTest.fs
+++ b/tests/FSharpx.Collections.Tests/RandomAccessListTest.fs
@@ -12,6 +12,7 @@ open Expecto.Flip
 module RandomAccessListTest =
     let emptyRandomAccessList = RandomAccessList.empty
 
+    [<Tests>]
     let testRandomAccessList =
 
         testList "RandomAccessList" [

--- a/tests/FSharpx.Collections.Tests/RunTests.fs
+++ b/tests/FSharpx.Collections.Tests/RunTests.fs
@@ -1,57 +1,9 @@
 namespace FSharpx.Collections.Tests
 
 open Expecto
+open Expecto.Impl
 
 module RunTests =
 
     [<EntryPoint>]
-    let main args =
-
-        Tests.runTestsWithArgs defaultConfig args ArrayTests.testArray |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ByteStringTests.testByteString |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ResizeArrayTests.testResizeArray |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DequeTests.testDeque |> ignore
-        Tests.runTestsWithArgs defaultConfig args DequeTests.propertyTestDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DictionaryExtensionsTests.testDictionaryExtensions |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DListTests.testDList |> ignore
-        Tests.runTestsWithArgs defaultConfig args DListTests.propertyTestDList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args HeapTests.testHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args HeapTests.propertyTestHeap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args LazyList.testLazyList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ListExtensionsTests.testListExtensions |> ignore
-        Tests.runTestsWithArgs defaultConfig args ListExtensionsTests.propertyTestListExtensions |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args MapExtensionsTests.testMapExtensions |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args MapTests.testMap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args NameValueCollectionTests.testNameValueCollection |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args NonEmptyListTests.testNonEmptyList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PriorityQueueTests.testPriorityQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args QueueTests.testQueue |> ignore
-        Tests.runTestsWithArgs defaultConfig args QueueTests.propertyTestQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RandomAccessListTest.testRandomAccessList |> ignore
-        Tests.runTestsWithArgs defaultConfig args RandomAccessListTest.propertyTestRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args SeqTests.testSeq |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PersistentVectorTests.testPersistentVector |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args TransientHashMapTests.testTransientHashMap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PersistentHashMapTests.testPersistentHashMap |> ignore
-
-        0
-
+    let main args = runTestsInAssembly ExpectoConfig.defaultConfig args

--- a/tests/FSharpx.Collections.Tests/SeqTests.fs
+++ b/tests/FSharpx.Collections.Tests/SeqTests.fs
@@ -8,6 +8,7 @@ open Expecto
 open Expecto.Flip
 
 module SeqTests =
+    [<Tests>]
     let testSeq =
 
         let data = [1.;2.;3.;4.;5.;6.;7.;8.;9.;10.]

--- a/tests/FSharpx.Collections.Tests/TransientHashMapTest.fs
+++ b/tests/FSharpx.Collections.Tests/TransientHashMapTest.fs
@@ -30,6 +30,7 @@ module TransientHashMapTests =
 
         override __.GetHashCode () = 42
 
+    [<Tests>]
     let testTransientHashMap =
 
         testList "TransientHashMap" [


### PR DESCRIPTION
The previous implementation was problematic, given that Expecto's help was displayed many times.
The tests might also parallelize better.
And fixed a typo.