### PR TITLE
WIP: Fix #114 and add functions to compare lazy lists

### DIFF
--- a/src/FSharpx.Collections.Experimental/RoseTree.fs
+++ b/src/FSharpx.Collections.Experimental/RoseTree.fs
@@ -2,31 +2,28 @@
 
 open FSharpx.Collections
 open System
-open System.Linq
 open System.Runtime.CompilerServices
 
 /// Multi-way tree, also known as rose tree.
 // Ported from http://hackage.haskell.org/packages/archive/containers/latest/doc/html/src/Data-Tree.html
 [<CustomEquality; NoComparison>]
-type RoseTree<[<EqualityConditionalOn>] 'T> = 
-    { Root: 'T; Children: RoseForest<'T> }
+type RoseTree<[<EqualityConditionalOn>] 'T> =
+    { Root: 'T; Children: LazyList<RoseTree<'T>> }
 
-    override x.Equals y = 
+    override x.Equals y =
         match y with
         | :? RoseTree<'T> as y ->
             (x :> _ IEquatable).Equals y
         | _ -> false
 
-    override x.GetHashCode() = 
+    override x.GetHashCode() =
         391
         + (box x.Root).GetHashCode() * 23
         + (x.Children :> _ seq).GetHashCode()
 
     interface IEquatable<RoseTree<'T>> with
-        member x.Equals y = 
-            obj.Equals(x.Root, y.Root) && (x.Children :> _ seq).SequenceEqual y.Children
-            
-and RoseForest<'T> = LazyList<RoseTree<'T>>
+        member x.Equals y =
+            Unchecked.equals x.Root y.Root && LazyList.areEqual Unchecked.equals x.Children y.Children
 
 module L = LazyList
 
@@ -40,13 +37,13 @@ module RoseTree =
 
     let inline singleton x = create x L.empty
 
-    let rec map f (x: _ RoseTree) = 
+    let rec map f (x: _ RoseTree) =
         { RoseTree.Root = f x.Root
           Children = L.map (map f) x.Children }
 
     let rec ap x f =
         { RoseTree.Root = f.Root x.Root
-          Children = 
+          Children =
             let a = L.map (map f.Root) x.Children
             let b = L.map (fun c -> ap x c) f.Children
             L.append a b }
@@ -81,16 +78,16 @@ module RoseTree =
     and unfoldForest f =
         L.map (unfold f)
 
-    /// Behaves like a combination of map and fold; 
-    /// it applies a function to each element of a tree, 
-    /// passing an accumulating parameter, 
+    /// Behaves like a combination of map and fold;
+    /// it applies a function to each element of a tree,
+    /// passing an accumulating parameter,
     /// and returning a final value of this accumulator together with the new tree.
     let rec mapAccum f state tree =
         let nstate, root = f state tree.Root
         let nstate, children = LazyList.mapAccum (mapAccum f) nstate tree.Children
         nstate, create root children
-        
-// TODO: 
+
+// TODO:
 // bfs: http://pdf.aminer.org/000/309/950/the_under_appreciated_unfold.pdf
 // sequence / mapM / filterM
 // zipper: http://hackage.haskell.org/package/rosezipper-0.2

--- a/src/FSharpx.Collections.Experimental/RoseTree.fs
+++ b/src/FSharpx.Collections.Experimental/RoseTree.fs
@@ -23,7 +23,7 @@ type RoseTree<[<EqualityConditionalOn>] 'T> =
 
     interface IEquatable<RoseTree<'T>> with
         member x.Equals y =
-            Unchecked.equals x.Root y.Root && LazyList.areEqual Unchecked.equals x.Children y.Children
+            Unchecked.equals x.Root y.Root && LazyList.equalsWith Unchecked.equals x.Children y.Children
 
 module L = LazyList
 

--- a/src/FSharpx.Collections/LazyList.fs
+++ b/src/FSharpx.Collections/LazyList.fs
@@ -348,11 +348,11 @@ module LazyList =
         | Cons _, Nil -> 1
         | Nil, Cons _ -> -1
 
-    let rec areEqual (fEquality: 'a -> 'a -> _) source1 source2 =
+    let rec equalsWith (fEquality: 'a -> 'a -> _) source1 source2 =
         match source1, source2 with
         | Nil, Nil -> true
         | Cons (x1, xs1), Cons (x2, xs2) ->
             match fEquality x1 x2 with
-            | true -> areEqual fEquality xs1 xs2
+            | true -> equalsWith fEquality xs1 xs2
             | false -> false
         | Cons _, Nil | Nil, Cons _ -> false

--- a/src/FSharpx.Collections/LazyList.fs
+++ b/src/FSharpx.Collections/LazyList.fs
@@ -337,3 +337,22 @@ module LazyList =
             | 0 -> leftL, (ll'.Tail)
             | _ -> loop (z - 1)  ((ll'.Head)::leftL) (ll'.Tail)
         loop n [] ll
+
+    let rec compareWith (comparer: 'a -> 'a -> _) source1 source2 =
+        match source1, source2 with
+        | Nil, Nil -> 0
+        | Cons (x1, xs1), Cons (x2, xs2) ->
+            match comparer x1 x2 with
+            | 0 -> compareWith comparer xs1 xs2
+            | x -> x
+        | Cons _, Nil -> 1
+        | Nil, Cons _ -> -1
+
+    let rec areEqual (fEquality: 'a -> 'a -> _) source1 source2 =
+        match source1, source2 with
+        | Nil, Nil -> true
+        | Cons (x1, xs1), Cons (x2, xs2) ->
+            match fEquality x1 x2 with
+            | true -> areEqual fEquality xs1 xs2
+            | false -> false
+        | Cons _, Nil | Nil, Cons _ -> false

--- a/src/FSharpx.Collections/LazyList.fsi
+++ b/src/FSharpx.Collections/LazyList.fsi
@@ -216,7 +216,7 @@ module LazyList =
 
     ///O(n). Checks if two lazy lists are equal using the given equality function, element by element.
     /// Both lists are evaluated until one of them is empty.
-    val areEqual    : ('T -> 'T -> bool) -> LazyList<'T> -> LazyList<'T> -> bool
+    val equalsWith     : ('T -> 'T -> bool) -> LazyList<'T> -> LazyList<'T> -> bool
 
     //--------------------------------------------------------------------------
     // Lazy list active patterns

--- a/src/FSharpx.Collections/LazyList.fsi
+++ b/src/FSharpx.Collections/LazyList.fsi
@@ -1,32 +1,32 @@
-// First version copied from the F# Power Pack 
+// First version copied from the F# Power Pack
 // https://raw.github.com/fsharp/powerpack/master/src/FSharp.PowerPack/LazyList.fsi
 
-// (c) Microsoft Corporation 2005-2009. 
+// (c) Microsoft Corporation 2005-2009.
 
 namespace FSharpx.Collections
 
 open System.Collections.Generic
 
 /// LazyLists are possibly-infinite, cached sequences.  See also IEnumerable/Seq for
-/// uncached sequences. LazyLists normally involve delayed computations without 
-/// side-effects.  The results of these computations are cached and evaluations will be 
-/// performed only once for each element of the lazy list.  In contrast, for sequences 
-/// (IEnumerable) recomputation happens each time an enumerator is created and the sequence 
+/// uncached sequences. LazyLists normally involve delayed computations without
+/// side-effects.  The results of these computations are cached and evaluations will be
+/// performed only once for each element of the lazy list.  In contrast, for sequences
+/// (IEnumerable) recomputation happens each time an enumerator is created and the sequence
 /// traversed.
 ///
-/// LazyLists can represent cached, potentially-infinite computations.  Because they are 
-/// cached they may cause memory leaks if some active code or data structure maintains a 
-/// live reference to the head of an infinite or very large lazy list while iterating it, 
+/// LazyLists can represent cached, potentially-infinite computations.  Because they are
+/// cached they may cause memory leaks if some active code or data structure maintains a
+/// live reference to the head of an infinite or very large lazy list while iterating it,
 /// or if a reference is maintained after the list is no longer required.
 ///
-/// Lazy lists may be matched using the LazyList.Cons and LazyList.Nil active patterns. 
+/// Lazy lists may be matched using the LazyList.Cons and LazyList.Nil active patterns.
 /// These may force the computation of elements of the list.
 
 [<Sealed>]
 type LazyList<'T> =
     interface IEnumerable<'T>
     interface System.Collections.IEnumerable
-    
+
     ///O(1). Test if a list is empty.  Forces the evaluation of
     /// the first element of the stream if it is not already evaluated.
     member IsEmpty : bool
@@ -42,11 +42,11 @@ type LazyList<'T> =
     /// the first cell of the list if it is not already evaluated.
     member TryHead : 'T option
 
-    ///O(1). Return the list corresponding to the remaining items in the sequence.  
+    ///O(1). Return the list corresponding to the remaining items in the sequence.
     /// Forces the evaluation of the first cell of the list if it is not already evaluated.
     member Tail : LazyList<'T>
 
-    ///O(1). Return option the list corresponding to the remaining items in the sequence.  
+    ///O(1). Return option the list corresponding to the remaining items in the sequence.
     /// Forces the evaluation of the first cell of the list if it is not already evaluated.
     member TryTail : LazyList<'T> option
 
@@ -71,11 +71,11 @@ module LazyList =
     /// the first cell of the list if it is not already evaluated.
     val tryHead       : LazyList<'T> -> 'T option
 
-    ///O(1). Return the list corresponding to the remaining items in the sequence.  
+    ///O(1). Return the list corresponding to the remaining items in the sequence.
     /// Forces the evaluation of the first cell of the list if it is not already evaluated.
     val tail       : LazyList<'T> -> LazyList<'T>
 
-    ///O(1). Return option the list corresponding to the remaining items in the sequence.  
+    ///O(1). Return option the list corresponding to the remaining items in the sequence.
     /// Forces the evaluation of the first cell of the list if it is not already evaluated.
     val tryTail       : LazyList<'T> -> LazyList<'T> option
 
@@ -85,33 +85,33 @@ module LazyList =
     ///O(1). Returns option tuple of head element and tail of the list.
     val tryUncons      : LazyList<'T> -> ('T * LazyList<'T>) option
 
-    ///O(n), where n is count. Return the list which on consumption will consist of at most 'n' elements of 
-    /// the input list.  
+    ///O(n), where n is count. Return the list which on consumption will consist of at most 'n' elements of
+    /// the input list.
     val take     : count:int -> source:LazyList<'T> -> LazyList<'T>
 
-    ///O(n), where n is count. Return the list which on consumption will remove of at most 'n' elements of 
-    /// the input list.  
+    ///O(n), where n is count. Return the list which on consumption will remove of at most 'n' elements of
+    /// the input list.
     val drop     : count:int -> source:LazyList<'T> -> LazyList<'T>
 
-    ///O(n), where n is count. Return the list which on consumption will consist of at most 'n' elements of 
-    /// the input list.  
+    ///O(n), where n is count. Return the list which on consumption will consist of at most 'n' elements of
+    /// the input list.
     val tryTake     : count:int -> source:LazyList<'T> -> LazyList<'T> option
 
-    ///O(n), where n is count. Return the list which on consumption will skip the first 'n' elements of 
-    /// the input list.  
+    ///O(n), where n is count. Return the list which on consumption will skip the first 'n' elements of
+    /// the input list.
     val skip     : count:int -> source:LazyList<'T> -> LazyList<'T>
 
-    ///O(n), where n is count. Return option the list which skips the first 'n' elements of 
-    /// the input list.  
+    ///O(n), where n is count. Return option the list which skips the first 'n' elements of
+    /// the input list.
     val trySkip     : count:int -> source:LazyList<'T> -> LazyList<'T> option
 
     ///O(n). /// it applies a function to each element of a list,
     /// passing an accumulating parameter from left to right,
     val fold     : f:('T1 -> 'T2 -> 'T1) -> s:'T1 -> l:LazyList<'T2> -> 'T1
 
-    ///O(n). Behaves like a combination of map and fold; 
-    /// it applies a function to each element of a list, 
-    /// passing an accumulating parameter from left to right, 
+    ///O(n). Behaves like a combination of map and fold;
+    /// it applies a function to each element of a list,
+    /// passing an accumulating parameter from left to right,
     /// and returning a final value of this accumulator together with the new list.
     val mapAccum     : f:('T1 -> 'T2 -> 'T1 * 'T3) -> s:'T1 -> l:LazyList<'T2> -> 'T1 * LazyList<'T3>
 
@@ -122,7 +122,7 @@ module LazyList =
 
     ///O(n), worst case. Return the first element for which the given function returns <c>true</c>.
     /// Raise <c>KeyNotFoundException</c> if no such element exists.
-    val find     : predicate:('T -> bool) -> source:LazyList<'T> -> 'T 
+    val find     : predicate:('T -> bool) -> source:LazyList<'T> -> 'T
 
     ///O(1). Evaluates to the list that contains no items
     [<GeneralizableValue>]
@@ -135,11 +135,11 @@ module LazyList =
     /// given list.
     val cons     : 'T -> LazyList<'T>               -> LazyList<'T>
 
-    ///O(1). Return a new list which on consumption contains the given item 
-    /// followed by the list returned by the given computation.  The 
+    ///O(1). Return a new list which on consumption contains the given item
+    /// followed by the list returned by the given computation.  The
     val consDelayed    : 'T -> (unit -> LazyList<'T>)     -> LazyList<'T>
 
-    ///O(1). Return the list which on consumption will consist of an infinite sequence of 
+    ///O(1). Return the list which on consumption will consist of an infinite sequence of
     /// the given item
     val repeat   : 'T -> LazyList<'T>
 
@@ -171,12 +171,12 @@ module LazyList =
     /// for which the given predicate returns "true"
     val filter   : predicate:('T -> bool) -> source:LazyList<'T> -> LazyList<'T>
 
-    ///O(n). Apply the given function to each element of the collection. 
+    ///O(n). Apply the given function to each element of the collection.
     val iter: action:('T -> unit) -> list:LazyList<'T>-> unit
 
     ///O(1). Return a new list consisting of the results of applying the given accumulating function
     /// to successive elements of the list
-    val scan    : folder:('State -> 'T -> 'State) -> 'State -> source:LazyList<'T> -> LazyList<'State>  
+    val scan    : folder:('State -> 'T -> 'State) -> 'State -> source:LazyList<'T> -> LazyList<'State>
 
     ///O(1). Build a new collection whose elements are the results of applying the given function
     /// to each of the elements of the collection.
@@ -186,19 +186,19 @@ module LazyList =
     /// to the corresponding elements of the two collections pairwise.
     val map2     : mapping:('T1 -> 'T2 -> 'U) -> LazyList<'T1> -> LazyList<'T2> -> LazyList<'U>
 
-    ///O(1). Build a collection from the given array. This function will eagerly evaluate all of the 
-    /// list (and thus may not terminate). 
+    ///O(1). Build a collection from the given array. This function will eagerly evaluate all of the
+    /// list (and thus may not terminate).
     val ofArray : 'T array -> LazyList<'T>
 
     ///O(n). Build an array from the given collection
     val toArray : LazyList<'T> -> 'T array
 
-    ///O(1). Build a collection from the given list. This function will eagerly evaluate all of the 
-    /// list (and thus may not terminate). 
+    ///O(1). Build a collection from the given list. This function will eagerly evaluate all of the
+    /// list (and thus may not terminate).
     val ofList  : list<'T> -> LazyList<'T>
 
-    ///O(n). Build a non-lazy list from the given collection. This function will eagerly evaluate all of the 
-    /// list (and thus may not terminate). 
+    ///O(n). Build a non-lazy list from the given collection. This function will eagerly evaluate all of the
+    /// list (and thus may not terminate).
     val toList  : LazyList<'T> -> list<'T>
 
     ///O(n). Return a view of the collection as an enumerable object
@@ -210,6 +210,13 @@ module LazyList =
     /// Returns the reverse list.
     val rev: LazyList<'T> -> LazyList<'T>
 
+    ///O(n). Compares two lazy lists using the given comparison function, element by element.
+    /// Both lists are evaluated until one of them is empty.
+    val compareWith    : ('T -> 'T -> int) -> LazyList<'T> -> LazyList<'T> -> int
+
+    ///O(n). Checks if two lazy lists are equal using the given equality function, element by element.
+    /// Both lists are evaluated until one of them is empty.
+    val areEqual    : ('T -> 'T -> bool) -> LazyList<'T> -> LazyList<'T> -> bool
 
     //--------------------------------------------------------------------------
     // Lazy list active patterns

--- a/tests/FSharpx.Collections.Experimental.Tests/RoseTreeTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/RoseTreeTest.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharpx.Collections.Experimental.Tests
+namespace FSharpx.Collections.Experimental.Tests
 
 open FsCheck
 open FSharpx.Collections
@@ -144,7 +144,7 @@ module RoseTreeTest =
         let inline (>>=) m f = RoseTree.bind f m
         let ret = RoseTree.singleton
 
-        testList "Experimental RoseTree propeerties" [
+        testList "Experimental RoseTree properties" [
 
             ptestPropertyWithConfig config10k "RoseTree functor laws: preserves identity" 
                 (Prop.forAll (roseTree()) <|

--- a/tests/FSharpx.Collections.Experimental.Tests/RoseTreeTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/RoseTreeTest.fs
@@ -81,13 +81,17 @@ module RoseTreeTest =
     let testRoseTreeProperties =
 
         let roseTree() = 
-            gen {
-                let! root = Arb.generate<obj>
-                // need to set these frequencies to avoid blowing the stack
-                let! children = Gen.frequency [70, gen.Return LazyList.empty<RoseTree<obj>>; 1, Gen.finiteLazyList()]
-                return RoseTree.create root children 
-            }
-            |> Arb.fromGen
+            let rec impl s =
+                gen {
+                        let! root = Arb.generate
+                    // need to set these frequencies to avoid blowing the stack
+                        let! children =
+                            match s with
+                            | s when s > 0 -> Gen.frequency [70, Gen.constant LazyList.empty; 1, impl (s/2) |> Gen.listOf |> Gen.map LazyList.ofList]
+                            | _ -> Gen.constant LazyList.empty
+                    return RoseTree.create root children 
+                }
+            impl |> Gen.sized |> Arb.fromGen
 
         let roseTreeOfObj n (o : obj) =
             let tail =
@@ -112,8 +116,8 @@ module RoseTreeTest =
 
         let composition() =
             gen {
-                let f = fun x -> x
-                let g = fun x -> x
+                let f = id
+                let g = id
                 let! n = Arb.generate<int> |> Gen.filter (fun n -> n > 0 && n < 10)
 
                 let! xs = Gen.listObj n |> Gen.filter (fun x -> x.Length > 0 && x.Length < 100)
@@ -146,7 +150,7 @@ module RoseTreeTest =
 
         testList "Experimental RoseTree properties" [
 
-            ptestPropertyWithConfig config10k "RoseTree functor laws: preserves identity" 
+            testPropertyWithConfig config10k "RoseTree functor laws: preserves identity"
                 (Prop.forAll (roseTree()) <|
                     fun value -> map id value = value )
 
@@ -158,7 +162,7 @@ module RoseTreeTest =
                 (Prop.forAll (leftIdentity()) <|
                     fun (f, a) -> ret a >>= f = f a )
 
-            ptestPropertyWithConfig config10k "RoseTree monad laws : right identity" 
+            testPropertyWithConfig config10k "RoseTree monad laws : right identity"
                 (Prop.forAll (roseTree()) <|
                     fun x -> x >>= ret = x )
 

--- a/tests/FSharpx.Collections.Experimental.Tests/RunTests.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/RunTests.fs
@@ -1,83 +1,9 @@
 namespace FSharpx.Collections.Experimental.Tests
 
 open Expecto
+open Expecto.Impl
 
 module RunTests =
 
     [<EntryPoint>]
-    let main args =
-
-        Tests.runTestsWithArgs defaultConfig args AltBinaryRandomAccessListTest.testAltBinaryRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BankersDequeTest.testBankersDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BatchDequeTest.testBatchDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinaryRandomAccessListTest.testBinaryRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinaryRoseTreeTest.testBinaryRoseTree |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinaryTreeZipperTest.testBinaryTreeZipper |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BinomialHeapTest.testBinomialHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args BinomialHeapTest.propertyBinomialHeap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BKTreeTest.testBKTree |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BlockResizeArrayTest.testBlockResizeArray |> ignore
-        Tests.runTestsWithArgs defaultConfig args BlockResizeArrayTest.testBlockResizeArrayPropeerties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BootstrappedQueueTest.testBootstrappedQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args BottomUpMergeSortTest.testBottomUpMergeSort |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DequeTest.testDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DListTest.testDList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args EagerRoseTreeTest.testEagerRoseTree |> ignore
-        Tests.runTestsWithArgs defaultConfig args EagerRoseTreeTest.testEagerRoseTreePropeerties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args EditDistanceTest.testEditDistance |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args FileSystemZipperTest.testFileSystemZipper |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args FlatListTest.testFlatList |> ignore
-        Tests.runTestsWithArgs defaultConfig args FlatListTest.testFlatListProperties|> ignore
-
-        Tests.runTestsWithArgs defaultConfig args HeapPriorityQueueTest.testHeapPriorityQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ImplicitQueueTest.testImplicitQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args IndexedRoseTreeTest.testIndexedRoseTree |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args IntMapTest.testIntMap |> ignore
-        Tests.runTestsWithArgs defaultConfig args IntMapTest.testIntMapProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args IQueueTest.testIQueue |> ignore
-        Tests.runTestsWithArgs defaultConfig args IQueueTest.testIQueueProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args LeftistHeapTest.testLeftistHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args LeftistHeapTest.testLeftistHeapProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ListZipperTest.testListZipper |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PairingHeapTest.testPairingHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args PairingHeapTest.testPairingHeapProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RealTimeDequeTest.testRealTimeDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RealTimeQueueTest.testRealTimeQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RingBufferTest.testRingBuffer |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RoseTreeTest.testRoseTree |> ignore
-        Tests.runTestsWithArgs defaultConfig args RoseTreeTest.testRoseTreeProperties |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args SkewBinaryRandomAccessListTest.testSkewBinaryRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args SkewBinomialHeapTest.testSkewBinomialHeap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args TimeSeriesTest.testTimeSeries |> ignore
-    
-        0
+    let main args = runTestsInAssembly ExpectoConfig.defaultConfig args

--- a/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/SkewBinomialHeapTest.fs
@@ -120,7 +120,7 @@ module SkewBinomialHeapTest =
     let iComparableGen() : Gen<IComparable> =
         gen{
             let! t = 
-                Arb.generate<'T> 
+                Arb.generate
                 |> Gen.filter (fun x ->
                         match x :> obj with 
                         | :? System.IComparable -> true 

--- a/tests/FSharpx.Collections.Tests/LazyListTests.fs
+++ b/tests/FSharpx.Collections.Tests/LazyListTests.fs
@@ -225,6 +225,9 @@ module LazyList =
             test "array take6"  {Expect.equal "array" (LazyList.toList (LazyList.take 6 nats)) <| Array.toList (LazyList.toArray (LazyList.take 6 nats)) } 
             test "array list"  {Expect.equal "array" (LazyList.toList (LazyList.ofArray [|1;2;3;4|])) <| LazyList.toList (LazyList.ofList [1;2;3;4]) }
 
+            test "equalsWith" {Expect.isTrue "equalsWith" <| LazyList.equalsWith (=) (LazyList.ofList [1;2;3;4;5]) (LazyList.ofList [1..5]) }
+            test "compareWith" {Expect.equal "compareWith" -1 <| LazyList.compareWith Unchecked.compare (LazyList.ofList [1;2;3;4]) (LazyList.ofList [1..5]) }
+
             // This checks that LazyList.map, LazyList.length etc. are tail recursive
             test "LazyList.length 100" {Expect.equal "length" 100 (LazyList.ofSeq (Seq.init 100 (fun c -> c)) |> LazyList.length) }
             test "LazyList.length 1000000" {Expect.equal "length" 1000000 (LazyList.ofSeq (Seq.init 1000000 (fun c -> c)) |> LazyList.length) }

--- a/tests/FSharpx.Collections.Tests/ListExtensionsTest.fs
+++ b/tests/FSharpx.Collections.Tests/ListExtensionsTest.fs
@@ -7,6 +7,7 @@ open Expecto.Flip
 
 module ListExtensionsTests =
 
+    [<Tests>]
     let testListExtensions =
         testList "ListExtensions" [
 
@@ -71,6 +72,7 @@ module ListExtensionsTests =
                 Expect.equal "transpose" expected (a |> List.transpose) }
         ]
 
+    [<Tests>]
     let propertyTestListExtensions =
         let fill (total:int) (elem:'a) (list:'a list) = 
             let padded = List.fill total elem list 

--- a/tests/FSharpx.Collections.Tests/NameValueCollectionTests.fs
+++ b/tests/FSharpx.Collections.Tests/NameValueCollectionTests.fs
@@ -9,6 +9,7 @@ open Expecto.Flip
 
 module NameValueCollectionTests =
 
+    [<Tests>]
     let testNameValueCollection =
 
         let assertKeyIs (l: ILookup<_,_>) a key = 

--- a/tests/FSharpx.Collections.Tests/PersistentHashMapTest.fs
+++ b/tests/FSharpx.Collections.Tests/PersistentHashMapTest.fs
@@ -7,6 +7,7 @@ open Expecto
 open Expecto.Flip
 
 module PersistentHashMapTests =
+    [<Tests>]
     let testPersistentHashMap =
 
         testList "PersistentHashMap" [

--- a/tests/FSharpx.Collections.Tests/PersistentVectorTest.fs
+++ b/tests/FSharpx.Collections.Tests/PersistentVectorTest.fs
@@ -6,6 +6,7 @@ open Expecto
 open Expecto.Flip
 
 module PersistentVectorTests =
+    [<Tests>]
     let testPersistentVector =
 
         testList "PersistentVector" [

--- a/tests/FSharpx.Collections.Tests/PriorityQueueTest.fs
+++ b/tests/FSharpx.Collections.Tests/PriorityQueueTest.fs
@@ -5,6 +5,7 @@ open Expecto
 open Expecto.Flip
 
 module PriorityQueueTests =
+    [<Tests>]
     let testPriorityQueue =
 
         testList "PriorityQueue" [

--- a/tests/FSharpx.Collections.Tests/QueueTest.fs
+++ b/tests/FSharpx.Collections.Tests/QueueTest.fs
@@ -9,6 +9,7 @@ open Expecto.Flip
 module QueueTests =
     let emptyQueue = Queue.empty
 
+    [<Tests>]
     let testQueue =
 
         testList "Queue" [

--- a/tests/FSharpx.Collections.Tests/RandomAccessListTest.fs
+++ b/tests/FSharpx.Collections.Tests/RandomAccessListTest.fs
@@ -12,6 +12,7 @@ open Expecto.Flip
 module RandomAccessListTest =
     let emptyRandomAccessList = RandomAccessList.empty
 
+    [<Tests>]
     let testRandomAccessList =
 
         testList "RandomAccessList" [

--- a/tests/FSharpx.Collections.Tests/RunTests.fs
+++ b/tests/FSharpx.Collections.Tests/RunTests.fs
@@ -1,57 +1,9 @@
 namespace FSharpx.Collections.Tests
 
 open Expecto
+open Expecto.Impl
 
 module RunTests =
 
     [<EntryPoint>]
-    let main args =
-
-        Tests.runTestsWithArgs defaultConfig args ArrayTests.testArray |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ByteStringTests.testByteString |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ResizeArrayTests.testResizeArray |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DequeTests.testDeque |> ignore
-        Tests.runTestsWithArgs defaultConfig args DequeTests.propertyTestDeque |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DictionaryExtensionsTests.testDictionaryExtensions |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args DListTests.testDList |> ignore
-        Tests.runTestsWithArgs defaultConfig args DListTests.propertyTestDList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args HeapTests.testHeap |> ignore
-        Tests.runTestsWithArgs defaultConfig args HeapTests.propertyTestHeap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args LazyList.testLazyList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args ListExtensionsTests.testListExtensions |> ignore
-        Tests.runTestsWithArgs defaultConfig args ListExtensionsTests.propertyTestListExtensions |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args MapExtensionsTests.testMapExtensions |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args MapTests.testMap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args NameValueCollectionTests.testNameValueCollection |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args NonEmptyListTests.testNonEmptyList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PriorityQueueTests.testPriorityQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args QueueTests.testQueue |> ignore
-        Tests.runTestsWithArgs defaultConfig args QueueTests.propertyTestQueue |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args RandomAccessListTest.testRandomAccessList |> ignore
-        Tests.runTestsWithArgs defaultConfig args RandomAccessListTest.propertyTestRandomAccessList |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args SeqTests.testSeq |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PersistentVectorTests.testPersistentVector |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args TransientHashMapTests.testTransientHashMap |> ignore
-
-        Tests.runTestsWithArgs defaultConfig args PersistentHashMapTests.testPersistentHashMap |> ignore
-
-        0
-
+    let main args = runTestsInAssembly ExpectoConfig.defaultConfig args

--- a/tests/FSharpx.Collections.Tests/SeqTests.fs
+++ b/tests/FSharpx.Collections.Tests/SeqTests.fs
@@ -8,6 +8,7 @@ open Expecto
 open Expecto.Flip
 
 module SeqTests =
+    [<Tests>]
     let testSeq =
 
         let data = [1.;2.;3.;4.;5.;6.;7.;8.;9.;10.]

--- a/tests/FSharpx.Collections.Tests/TransientHashMapTest.fs
+++ b/tests/FSharpx.Collections.Tests/TransientHashMapTest.fs
@@ -30,6 +30,7 @@ module TransientHashMapTests =
 
         override __.GetHashCode () = 42
 
+    [<Tests>]
     let testTransientHashMap =
 
         testList "TransientHashMap" [


### PR DESCRIPTION
Quoting from #114:

> The tests die in FsCheck on the [equality comparison](https://github.com/fsprojects/FSharpx.Collections/blob/68acb6cb5e860ced24a03c95922e6809352b8c4b/src/FSharpx.Collections.Experimental/RoseTree.fs#L25)

As it turned out, they didn't die _there_; the culprit was the FsCheck `RoseTree` generator which is now fixed.

This PR also includes #119.

Regarding equality checks on `RoseTree`, this PR adds two functions to the public API of `LazyList`.

* The first one, `LazyList.compareWith` was added for consistency with the [core](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/seq.comparewith%5B%27t%5D-function-%5Bfsharp%5D) [library](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/list.comparewith%5b't%5d-function-%5bfsharp%5d) [functions](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/array.comparewith%5B%27t%5D-function-%5Bfsharp%5D). It works in the same way.

* The second one, `LazyList.areEqual` was added for the cases where the list items are not comparable and the caller just wants to check if the list is equal. ~~As for the name, I chose one on my own because there's not anything similar in the core library.~~ Looks like there is. I will rename it then to `LazyList.equalsWith`.

Both were documented, and it is clearly stated that both lists are evaluated.

As for the `RoseTree`, I don't think it should implement the equality interfaces because a simple `=` can have big side effects. I will create appropriate functions for there too.

### TODO

- [x] Rename `LazyList.areEqual` to `LazyList.equalsWith`.
- [x] Implement `RoseTree` equality functions.
- [x] Add tests for the new `LazyList` methods.