### PR TITLE
Replace internal refs with mutable vars

### DIFF
--- a/src/FSharpx.Collections/ByteString.fs
+++ b/src/FSharpx.Collections/ByteString.fs
@@ -54,27 +54,27 @@ type ByteString(array: byte[], offset: int, count: int) =
             let segment = x.Array
             let minIndex = x.Offset
             let maxIndex = x.Offset + x.Count - 1
-            let currentIndex = ref <| minIndex - 1
+            let mutable currentIndex = minIndex - 1
             { new IEnumerator<_> with 
                 member self.Current =
-                    if !currentIndex < minIndex then
+                    if currentIndex < minIndex then
                         invalidOp "Enumeration has not started. Call MoveNext."
-                    elif !currentIndex > maxIndex then
+                    elif currentIndex > maxIndex then
                         invalidOp "Enumeration already finished."
-                    else segment.[!currentIndex]
+                    else segment.[currentIndex]
               interface System.Collections.IEnumerator with
                 member self.Current =
-                    if !currentIndex < minIndex then
+                    if currentIndex < minIndex then
                         invalidOp "Enumeration has not started. Call MoveNext."
-                    elif !currentIndex > maxIndex then
+                    elif currentIndex > maxIndex then
                         invalidOp "Enumeration already finished."
-                    else box segment.[!currentIndex]
+                    else box segment.[currentIndex]
                 member self.MoveNext() = 
-                    if !currentIndex < maxIndex then
-                        incr currentIndex
+                    if currentIndex < maxIndex then
+                        currentIndex <- currentIndex + 1
                         true
                     else false
-                member self.Reset() = currentIndex := minIndex - 1
+                member self.Reset() = currentIndex <- minIndex - 1
               interface System.IDisposable with 
                 member self.Dispose() = () }
 

--- a/src/FSharpx.Collections/Collections.fs
+++ b/src/FSharpx.Collections/Collections.fs
@@ -199,12 +199,12 @@ module Seq =
         seq {
             use e = a.GetEnumerator()
             use e' = b.GetEnumerator()
-            let eNext = ref (e.MoveNext())
-            let eNext' = ref (e'.MoveNext())
-            while !eNext || !eNext' do
+            let mutable eNext = e.MoveNext()
+            let mutable eNext' = e'.MoveNext()
+            while eNext || eNext' do
                yield f e.Current e'.Current
-               eNext := e.MoveNext()
-               eNext' := e'.MoveNext()
+               eNext <- e.MoveNext()
+               eNext' <- e'.MoveNext()
         }
 
     /// Replicates each element in the seq n-times
@@ -223,11 +223,11 @@ module Seq =
 
     let intersperse (sep: 'a) (list: 'a seq) : 'a seq =
         seq {
-            let notFirst = ref false
+            let mutable notFirst = false
             for element in list do
-              if !notFirst then yield sep;
+              if notFirst then yield sep;
               yield element;
-              notFirst := true
+              notFirst <- true
       }
 
     /// The catOptions function takes a list of Options and returns a seq of all the Some values.
@@ -742,7 +742,7 @@ module NameValueCollection =
             member d.GetEnumerator() = a.GetEnumerator() :> IEnumerator
             member d.Remove (item: KeyValuePair<string,string[]>) = notSupported(); false
             member d.Remove (key: string) = notSupported(); false
-            member d.TryGetValue(key: string, value: byref<string[]>) = a.TryGetValue(key, ref value)
+            member d.TryGetValue(key: string, value: byref<string[]>) = a.TryGetValue(key, &value)
         }
 
     [<Extension>]

--- a/src/FSharpx.Collections/Deque.fs
+++ b/src/FSharpx.Collections/Deque.fs
@@ -6,19 +6,19 @@ open System.Collections
 open System.Collections.Generic
 
 type Deque<'T> (front, rBack) = 
-    let hashCode = ref None
+    let mutable hashCode = None
     member internal this.front = front
     member internal this.rBack = rBack
 
     override this.GetHashCode() =
-            match !hashCode with
-            | None ->
-                let mutable hash = 1
-                for x in this do
-                    hash <- 31 * hash + Unchecked.hash x
-                hashCode := Some hash
-                hash
-            | Some hash -> hash
+        match hashCode with
+        | None ->
+            let mutable hash = 1
+            for x in this do
+                hash <- 31 * hash + Unchecked.hash x
+            hashCode <- Some hash
+            hash
+        | Some hash -> hash
 
     override this.Equals(other) =
         match other with

--- a/src/FSharpx.Collections/PersistentHashMap.fs
+++ b/src/FSharpx.Collections/PersistentHashMap.fs
@@ -21,16 +21,16 @@ type internal INode =
 module private BitCount =
     let bitCounts = 
         let bitCounts = Array.create 65536 0
-        let position1 = ref -1
-        let position2 = ref -1
+        let mutable position1 = -1
+        let mutable position2 = -1
 
         for i in 1 .. 65535 do
-           if !position1 = !position2 then       
-                position1 := 0
-                position2 := i
+           if position1 = position2 then       
+                position1 <- 0
+                position2 <- i
 
-           bitCounts.[i] <- bitCounts.[!position1] + 1
-           position1 := !position1 + 1
+           bitCounts.[i] <- bitCounts.[position1] + 1
+           position1 <- position1 + 1
         bitCounts
 
     let inline NumberOfSetBits value =
@@ -63,22 +63,21 @@ module private NodeHelpers =
         System.Array.Copy(array, 2*(i+1), newArray, 2*i, newArray.Length - 2*i)
         newArray
 
-
     let inline createNodeSeq(array: obj[]) = 
         seq {
-            let j = ref 0
-            while !j < array.Length do                
-                let isNode = array.[!j+1] :? INode
+            let mutable j = 0
+            while j < array.Length do                
+                let isNode = array.[j+1] :? INode
                 
                 if isNode then
-                    let node = array.[!j+1] :?> INode
+                    let node = array.[j+1] :?> INode
                     if node <> Unchecked.defaultof<INode> then
                         yield! node.nodeSeq()
                 else
-                    if array.[!j] <> null then
-                        yield array.[!j],array.[!j+1]
+                    if array.[j] <> null then
+                        yield array.[j],array.[j+1]
             
-                j := !j + 2 }
+                j <- j + 2 }
              
 open BitCount
 open NodeHelpers
@@ -105,7 +104,6 @@ type private NodeCreation =
             .assoc(shift, key1hash, key1, val1, addedLeaf)
             .assoc(shift, key2hash, key2, val2, addedLeaf)
        
-
 and private HashCollisionNode(thread,hashCollisionKey,count',array':obj[]) =
     let thread = thread
     member val array = array' with get, set
@@ -113,10 +111,10 @@ and private HashCollisionNode(thread,hashCollisionKey,count',array':obj[]) =
         
     with
         member this.findIndex key =
-            let i = ref 0
-            while (!i < 2*this.count) && (key <> this.array.[!i]) do
-                i := !i + 2
-            if !i < 2*this.count then !i else -1
+            let mutable i = 0
+            while (i < 2*this.count) && (key <> this.array.[i]) do
+                i <- i + 2
+            if i < 2*this.count then i else -1
 
         member this.ensureEditable(thread1, count1, array1) =
             if !thread1 = !thread then
@@ -317,12 +315,12 @@ and private ArrayNode(thread,count',array':INode[]) =
 
             member this.nodeSeq() =
                  seq {
-                    let j = ref 0
-                    while !j < this.array.Length do
-                        if this.array.[!j] <> Unchecked.defaultof<INode> then
-                            yield! this.array.[!j].nodeSeq()
+                    let mutable j = 0
+                    while j < this.array.Length do
+                        if this.array.[j] <> Unchecked.defaultof<INode> then
+                            yield! this.array.[j].nodeSeq()
             
-                        j := !j + 1 }
+                        j <- j + 1 }
 
 
 and private BitmapIndexedNode(thread,bitmap',array':obj[]) =    

--- a/src/FSharpx.Collections/Queue.fs
+++ b/src/FSharpx.Collections/Queue.fs
@@ -3,17 +3,17 @@
 namespace FSharpx.Collections
 
 type Queue<'T> (front : list<'T>, rBack : list<'T>) = 
-    let hashCode = ref None
+    let mutable hashCode = None
     member internal this.front = front
     member internal this.rBack = rBack
 
     override this.GetHashCode() =
-        match !hashCode with
+        match hashCode with
         | None ->
             let mutable hash = 1
             for x in this do
                 hash <- 31 * hash + Unchecked.hash x
-            hashCode := Some hash
+            hashCode <- Some hash
             hash
         | Some hash -> hash
 

--- a/src/FSharpx.Collections/TaggedCollections.fs
+++ b/src/FSharpx.Collections/TaggedCollections.fs
@@ -477,13 +477,13 @@
                     not stack.IsEmpty
 
         let toSeq s = 
-            let i = ref (SetIterator s) 
+            let mutable i = SetIterator s
             { new IEnumerator<_> with 
-                  member __.Current = (!i).Current
+                  member __.Current = i.Current
               interface System.Collections.IEnumerator with 
-                  member __.Current = box (!i).Current
-                  member __.MoveNext() = (!i).MoveNext()
-                  member __.Reset() = i :=  SetIterator s
+                  member __.Current = box i.Current
+                  member __.MoveNext() = i.MoveNext()
+                  member __.Reset() = i <-  SetIterator s
               interface System.IDisposable with 
                   member __.Dispose() = () }
 
@@ -544,8 +544,8 @@
             loop s []            
 
         let copyToArray s (arr: _[]) i =
-            let j = ref i 
-            iter (fun x -> arr.[!j] <- x; j := !j + 1) s
+            let mutable j = i 
+            iter (fun x -> arr.[j] <- x; j <- j + 1) s
 
         let toArray s = 
             let n = (count s) 
@@ -1024,8 +1024,8 @@
             mkFromEnumerator comparer empty ie 
           
         let copyToArray s (arr: _[]) i =
-            let j = ref i 
-            s |> iter (fun x y -> arr.[!j] <- KeyValuePair(x,y); j := !j + 1)
+            let mutable j = i 
+            s |> iter (fun x y -> arr.[j] <- KeyValuePair(x,y); j <- j + 1)
 
 
         /// Imperative left-to-right iterators.
@@ -1083,13 +1083,13 @@
                   not stack.IsEmpty
 
         let toSeq s = 
-            let i = ref (MapIterator(s))
+            let mutable i = MapIterator(s)
             { new IEnumerator<_> with 
-                  member self.Current = (!i).Current
+                  member self.Current = i.Current
               interface System.Collections.IEnumerator with
-                  member self.Current = box (!i).Current
-                  member self.MoveNext() = (!i).MoveNext()
-                  member self.Reset() = i :=  MapIterator(s)
+                  member self.Current = box i.Current
+                  member self.MoveNext() = i.MoveNext()
+                  member self.Reset() = i <-  MapIterator(s)
               interface System.IDisposable with 
                   member self.Dispose() = ()}
 


### PR DESCRIPTION
Note: doesn't change any public APIs, some of which do have `ref` in their signature

Generally the use of `ref` makes code a bit more difficult to read. Additionally, it's a bit more performant to use mutable values too. Not sure if that really matters here, but a quick BenchmarkDotNet of running through big-ish arrays of `ref int`s and `mutable` ints will yield a 5% or so decrease in CPU time.