### PR TITLE
Remove FX_PORTABLE, FX_NO_THREAD and FX_NO_DEBUG_DISPLAYS conditional compilation.

### DIFF
--- a/docs/content/csharp/Properties/AssemblyInfo.cs
+++ b/docs/content/csharp/Properties/AssemblyInfo.cs
@@ -14,8 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-#if FX_PORTABLE
-#else
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -23,7 +21,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0b1f8cfc-0831-4ee6-a8d7-831782518564")]
-#endif
 
 // Version information for an assembly consists of the following four values:
 //

--- a/src/FSharpx.Collections.Experimental/IndexedRoseTree.fs
+++ b/src/FSharpx.Collections.Experimental/IndexedRoseTree.fs
@@ -1,7 +1,4 @@
 ﻿namespace FSharpx.Collections.Experimental
-
-#if FX_NO_THREAD
-#else
 open FSharpx
 open FSharpx.Collections
 open System
@@ -73,4 +70,3 @@ module IndexedRoseTree =
 
     and unfoldForest f =
         PersistentVector.map (unfold f)
-#endif

--- a/src/FSharpx.Collections/ByteString.fs
+++ b/src/FSharpx.Collections/ByteString.fs
@@ -5,11 +5,7 @@ open System.Collections
 open System.Collections.Generic
             
 /// An ArraySegment with structural comparison and equality.
-#if FX_PORTABLE
-[<CustomEquality; CustomComparison; StructAttribute>]
-#else
 [<CustomEquality; CustomComparison; SerializableAttribute; StructAttribute>]
-#endif
 type ByteString(array: byte[], offset: int, count: int) =
     new (array: byte[]) = ByteString(array, 0, array.Length)
 
@@ -107,16 +103,7 @@ module ByteString =
     let create arr = ByteString(arr, 0, arr.Length)
 
     /// needs .fsi file
-    let findIndex pred (bs:ByteString) =
-#if FX_PORTABLE
-        let rec loop i = 
-            if i >= bs.Count then -1 
-            elif pred bs.Array.[bs.Offset + i] then i
-            else loop (i+1)
-        loop 0
-#else
-        Array.FindIndex(bs.Array, bs.Offset, bs.Count, Predicate<_>(pred))
-#endif
+    let findIndex pred (bs:ByteString) = Array.FindIndex(bs.Array, bs.Offset, bs.Count, Predicate<_>(pred))
 
     /// needs .fsi file
     let ofArraySegment (segment:ArraySegment<byte>) = ByteString(segment.Array, segment.Offset, segment.Count)
@@ -141,11 +128,8 @@ module ByteString =
     /// needs .fsi file
     let toList (bs:ByteString) = List.ofSeq bs
 
-#if FX_PORTABLE
-#else
     /// needs .fsi file
     let toString (bs:ByteString) = System.Text.Encoding.ASCII.GetString(bs.Array, bs.Offset, bs.Count)
-#endif
 
     /// needs .fsi file
     let isEmpty (bs:ByteString) = 

--- a/src/FSharpx.Collections/Collections.fs
+++ b/src/FSharpx.Collections/Collections.fs
@@ -574,8 +574,6 @@ module Map =
         Array.compareWith (fun x y -> if eq x y then 0 else 1) xs' ys' = 0
 
 
-#if FX_PORTABLE
-#else
 [<Extension>]
 /// Extensions for NameValueCollections.
 [<RequireQualifiedAccess>]
@@ -775,4 +773,3 @@ module NameValueCollection =
             member x.Contains key = this.Get key <> null
             member x.GetEnumerator() = getEnumerator()
             member x.GetEnumerator() = getEnumerator() :> IEnumerator }
-#endif

--- a/src/FSharpx.Collections/Infrastructure.fs
+++ b/src/FSharpx.Collections/Infrastructure.fs
@@ -1,7 +1,5 @@
 ﻿module internal FSharpx.Collections.TimeMeasurement
 
-#if FX_PORTABLE
-#else
 /// Stops the runtime for a given function
 let stopTime f = 
     let sw = new System.Diagnostics.Stopwatch()
@@ -28,4 +26,3 @@ let printInFsiTags s = printfn " [fsi:%s]" s
 let averageTime count desc f =
     let time = stopAverageTime count f
     sprintf "%s %Ams" desc time |> printInFsiTags
-#endif

--- a/src/FSharpx.Collections/PersistentHashMap.fs
+++ b/src/FSharpx.Collections/PersistentHashMap.fs
@@ -1,8 +1,6 @@
 ﻿// vector implementation ported from https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/APersistentMap.java
 
 namespace FSharpx.Collections
-#if FX_NO_THREAD
-#else
 open System.Threading
 open System.Collections.Generic
 
@@ -720,4 +718,3 @@ module PersistentHashMap =
         for (key,value) in map do
             ret <- ret.Add(key,f value)
         ret.persistent() 
-#endif

--- a/src/FSharpx.Collections/PersistentVector.fs
+++ b/src/FSharpx.Collections/PersistentVector.fs
@@ -3,8 +3,6 @@
 namespace FSharpx.Collections
 
 open FSharpx.Collections
-#if FX_NO_THREAD
-#else
 open System.Threading
 
 type Node(thread,array:obj[]) =
@@ -464,4 +462,3 @@ module PersistentVector =
     let inline windowSeq windowLength (items : 'T seq) = 
         if windowLength < 1 then invalidArg "windowLength" "length is less than 1"
         else (Seq.fold (windowFun windowLength) (empty.Conj empty<'T>) items)
-#endif

--- a/src/FSharpx.Collections/PersistentVector.fsi
+++ b/src/FSharpx.Collections/PersistentVector.fsi
@@ -1,6 +1,4 @@
 ﻿namespace FSharpx.Collections
-#if FX_NO_THREAD
-#else
 /// PersistentVector is an ordered linear structure implementing the inverse of the List signature, 
 /// (last, initial, conj) in place of (head, tail, cons). Length is O(1). Indexed lookup or update
 /// (returning a new immutable instance of Vector) of any element is O(log32n), which is close enough
@@ -148,4 +146,3 @@ module PersistentVector =
 
     /// O(n). Returns a vector of vectors of given length from the seq. Result may be a jagged vector.
     val inline windowSeq : int  -> seq<'T> -> PersistentVector<PersistentVector<'T>>
-#endif

--- a/src/FSharpx.Collections/RandomAccessList.fs
+++ b/src/FSharpx.Collections/RandomAccessList.fs
@@ -14,8 +14,6 @@ module internal Literals2 =
     let internal blockIndexMask = 0x01f
 
 open System.Threading
-#if FX_NO_THREAD
-#else
 [<Serializable>]
 type NodeR(threadId,array:obj[]) =
     let mutable threadId = threadId
@@ -446,4 +444,3 @@ module RandomAccessList =
     let inline windowSeq windowLength (items: 'T seq) =
         if windowLength < 1 then invalidArg "windowLength" "length is less than 1"
         else (Seq.foldBack (windowFun windowLength) items (empty.Cons empty<'T>)) (*Seq.fold (windowFun windowLength) (empty.Cons empty<'T>) items*) // TODO: Check if this should be foldBack due to inversion effects of prepending
-#endif

--- a/src/FSharpx.Collections/RandomAccessList.fsi
+++ b/src/FSharpx.Collections/RandomAccessList.fsi
@@ -1,7 +1,4 @@
 ﻿namespace FSharpx.Collections
-
-#if FX_NO_THREAD
-#else
 /// RandomAccessList is an ordered linear structure implementing the List signature
 /// (head, tail, cons), as well as inspection (lookup) and update (returning a new
 /// immutable instance) of any element in the structure by index. Length is O(1). Indexed
@@ -146,4 +143,3 @@ module RandomAccessList =
 
     /// O(n). Returns a random access list of random access lists of given length from the seq. Result may be a jagged random access list.
     val inline windowSeq : int  -> seq<'T> -> RandomAccessList<RandomAccessList<'T>>
-#endif

--- a/src/FSharpx.Collections/TaggedCollections.fs
+++ b/src/FSharpx.Collections/TaggedCollections.fs
@@ -565,10 +565,7 @@
         let ofArray comparer l = Array.fold (fun acc k -> add comparer k acc) empty l    
 
 
-#if FX_NO_DEBUG_DISPLAYS
-#else
     [<System.Diagnostics.DebuggerDisplay ("Count = {Count}")>]
-#endif
     [<Sealed>]
     type Set<'T,'ComparerTag> when 'ComparerTag :> IComparer<'T>(comparer: IComparer<'T>, tree: SetTree<'T>) =
 
@@ -1094,10 +1091,7 @@
                   member self.Dispose() = ()}
 
 
-#if FX_NO_DEBUG_DISPLAYS
-#else
     [<System.Diagnostics.DebuggerDisplay ("Count = {Count}")>]
-#endif
     [<Sealed>]
     type Map<'Key,'T,'ComparerTag> when 'ComparerTag :> IComparer<'Key>( comparer: IComparer<'Key>, tree: MapTree<'Key,'T>) =
 


### PR DESCRIPTION
Usage of `FX_PORTABLE` and `FX_NO_THREAD` conditional compiling blocks  was ended in 955ae2bfea562d15dbf87b236d35b9d91a0ca5bd.

`FX_NO_DEBUG_DISPLAYS` was never used.