### PR TITLE
Unify namespaces for ResizeArray extensions and Tagged collections.

### DIFF
--- a/src/FSharpx.Collections/ResizeArray.fs
+++ b/src/FSharpx.Collections/ResizeArray.fs
@@ -3,7 +3,7 @@
 
 // (c) Microsoft Corporation 2005-2009. 
 
-namespace Microsoft.FSharp.Collections
+namespace FSharpx.Collections
 
 open Microsoft.FSharp.Core.OptimizedClosures
 

--- a/src/FSharpx.Collections/ResizeArray.fsi
+++ b/src/FSharpx.Collections/ResizeArray.fsi
@@ -7,7 +7,7 @@
 // (c) Microsoft Corporation 2005-2008.  
 //===========================================================================
 
-namespace Microsoft.FSharp.Collections
+namespace FSharpx.Collections
 
 open System
 open System.Collections.Generic

--- a/src/FSharpx.Collections/TaggedCollections.fs
+++ b/src/FSharpx.Collections/TaggedCollections.fs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.FSharp.Collections.Tagged
+﻿namespace FSharpx.Collections.Tagged
 //Copied from https://raw.github.com/fsharp/powerpack/master/src/FSharp.PowerPack/TaggedCollections.fs
 // (c) Microsoft Corporation 2005-2009. 
 

--- a/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
+++ b/tests/FSharpx.Collections.Experimental.Tests/BlockResizeArrayTest.fs
@@ -1,5 +1,6 @@
 ﻿namespace FSharpx.Collections.Experimental.Tests
 
+open FSharpx.Collections
 open FSharpx.Collections.Experimental
 open Expecto
 open Expecto.Flip
@@ -70,7 +71,7 @@ module BlockResizeArrayTest =
                 let ra = new ResizeArray<uint64>()
                 for i in 0..arraySize do ra.Add x
                 let bra = BlockResizeArray.Init arraySize (fun _ -> x)
-                averageTime testIters "ResizeArray map" (fun () -> (Microsoft.FSharp.Collections.ResizeArray.map (fun x -> x*2UL) ra)) 
+                averageTime testIters "ResizeArray map" (fun () -> (ResizeArray.map (fun x -> x*2UL) ra)) 
                 averageTime testIters "Array map" (fun () -> (Array.map (fun x -> x*2UL) a))       
                 averageTime testIters "BlockResizeArray map" (fun () -> bra.Map (fun x -> x*2UL)) }
 
@@ -79,7 +80,7 @@ module BlockResizeArrayTest =
                 let ra = new ResizeArray<uint64>()
                 for i in 0..arraySize do ra.Add x
                 let bra = BlockResizeArray.Init arraySize (fun _ -> x)
-                averageTime testIters "ResizeArray iter" (fun () -> (Microsoft.FSharp.Collections.ResizeArray.iter (fun i -> ()) ra)) 
+                averageTime testIters "ResizeArray iter" (fun () -> (ResizeArray.iter (fun i -> ()) ra)) 
                 averageTime testIters "Array iter" (fun () -> (Array.iter (fun i -> ())))       
                 averageTime testIters "BlockResizeArray iter" (fun () -> bra.Iter (fun i -> ())) }
 
@@ -88,7 +89,7 @@ module BlockResizeArrayTest =
                 let ra = new ResizeArray<uint64>()
                 for i in 0..arraySize do ra.Add x
                 let bra = BlockResizeArray.Init arraySize (fun _ -> x)
-                averageTime testIters "ResizeArray fold" (fun () -> (Microsoft.FSharp.Collections.ResizeArray.fold (fun x acc -> acc + x*2UL) 0UL ra)) 
+                averageTime testIters "ResizeArray fold" (fun () -> (ResizeArray.fold (fun x acc -> acc + x*2UL) 0UL ra)) 
                 averageTime testIters "Array fold" (fun () -> (Array.fold (fun x acc -> acc + x*2UL) 0UL a))       
                 averageTime testIters "BlockResizeArray fold" (fun () -> (FSharpx.Collections.Experimental.BlockResizeArray.fold (fun x acc -> acc + x*2UL) 0UL bra)) }
 
@@ -99,7 +100,7 @@ module BlockResizeArrayTest =
                 let s = 1010000
                 for i in 0..arraySize do ra.Add (x + i)
                 let bra = BlockResizeArray.Init arraySize (fun i -> x + i)
-                averageTime testIters "ResizeArray find" (fun () -> Microsoft.FSharp.Collections.ResizeArray.find (fun e -> e <> 0 && e % s = 0) ra)
+                averageTime testIters "ResizeArray find" (fun () -> ResizeArray.find (fun e -> e <> 0 && e % s = 0) ra)
                 averageTime testIters "Array find" (fun () -> (Array.find (fun e -> e <> 0 && e % s = 0) a))       
                 averageTime testIters "BlockResizeArray find" (fun () -> (FSharpx.Collections.Experimental.BlockResizeArray.find (fun e -> e <> 0 && e % s = 0) bra)) }
 #endif

--- a/tests/FSharpx.Collections.Tests/ResizeArrayTests.fs
+++ b/tests/FSharpx.Collections.Tests/ResizeArrayTests.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpx.Collections.Tests
 
-open Microsoft.FSharp.Collections
+open FSharpx.Collections
 open Expecto
 open Expecto.Flip
 


### PR DESCRIPTION
@jackfoxy please advise how to handling the breaking change nature of this change? Does this have to wait for 3.0?

The intention of changing the namespace for Tagged collection was signalized in #68 

Fix #68 (?)
Fix #144 