### PR TITLE
Fix FSharp.Core dependency version.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.1.1 - 2019-11-17
+* Fix FSharp.Core dependency version
+
 #### 2.1.0 - 2019-11-12
 * target net45 and netstandard2.0, thanks Grzegorz Dziadkiewicz
 

--- a/src/FSharpx.Collections.Experimental/paket.template
+++ b/src/FSharpx.Collections.Experimental/paket.template
@@ -24,9 +24,9 @@ description
     FSharpx.Collections is a collection of datastructures for use with F# and C#.
 dependencies
   framework: net45
-    FSharp.Core 4.3.4
+    FSharp.Core >= 4.3.4
   framework: netstandard20
-    FSharp.Core 4.3.4
+    FSharp.Core >= 4.3.4
 files
     ../../bin/FSharpx.Collections.Experimental/net45/FSharpx.Collections.Experimental.dll ==> lib/net45
     ../../bin/FSharpx.Collections.Experimental/net45/FSharpx.Collections.Experimental.pdb ==> lib/net45

--- a/src/FSharpx.Collections/paket.template
+++ b/src/FSharpx.Collections/paket.template
@@ -24,9 +24,9 @@ description
     FSharpx.Collections is a collection of datastructures for use with F# and C#.
 dependencies
   framework: net45
-    FSharp.Core 4.3.4
+    FSharp.Core >= 4.3.4
   framework: netstandard20
-    FSharp.Core 4.3.4
+    FSharp.Core >= 4.3.4
 files
     ../../bin/FSharpx.Collections/net45/FSharpx.Collections.dll ==> lib/net45
     ../../bin/FSharpx.Collections/net45/FSharpx.Collections.pdb ==> lib/net45


### PR DESCRIPTION
I made a mistake while editing paket.template files in #138 . It makes version 2.1.0 usable only with FSharp.Core 4.3.4 which was not intended.