### PR TITLE
Remove redundant framework specification.

### DIFF
--- a/tests/FSharpx.Collections.Experimental.Tests/FSharpx.Collections.Experimental.Tests.fsproj
+++ b/tests/FSharpx.Collections.Experimental.Tests/FSharpx.Collections.Experimental.Tests.fsproj
@@ -5,7 +5,6 @@
     <RootNamespace>FSharpx.Collections.Experimental.Tests</RootNamespace>
     <AssemblyName>FSharpx.Collections.Experimental.Tests</AssemblyName>
     <Name>FSharpx.Collections.Experimental.Tests</Name>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetFrameworks>net472;netcoreapp31</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/tests/FSharpx.Collections.Tests/FSharpx.Collections.Tests.fsproj
+++ b/tests/FSharpx.Collections.Tests/FSharpx.Collections.Tests.fsproj
@@ -5,7 +5,6 @@
     <RootNamespace>FSharpx.Collections.Tests</RootNamespace>
     <AssemblyName>FSharpx.Collections.Tests</AssemblyName>
     <Name>FSharpx.Collections.Tests</Name>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetFrameworks>net472;netcoreapp31</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateProgramFile>false</GenerateProgramFile>


### PR DESCRIPTION
The last merged PR contained a little bug that caused the tests to not be detected during the build. This fixes it.

Builds before:
https://travis-ci.org/github/fsprojects/FSharpx.Collections/jobs/692944015#L1834-L1837
https://ci.appveyor.com/project/fsgit/fsharpx-collections/builds/33216619#L368

Builds after:
https://ci.appveyor.com/project/sergey-tihon/fsharpx-collections/builds/33217878#L368
https://travis-ci.org/github/gdziadkiewicz/FSharpx.Collections/jobs/692960936#L1024-L1065