### PR TITLE
Use newer Mac version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
   - linux
   - osx
 dist: xenial # Ubuntu 16
+osx_image: xcode12.2
 
 install:
 


### PR DESCRIPTION
The default version (osx_image:osx) is xcode9.4, which uses macOS 10.13.
This is no longer supported by Apple or homebrew, so it was just a
matter of time before it broke.

This commit bumps to the newest available version.

References
- Versions: https://docs.travis-ci.com/user/reference/osx/#macos-version
- Discussion on 10.13 EOL: https://travis-ci.community/t/the-default-osx-image-xcode9-4-is-now-unusable-because-macos-10-13-is-eol/10628
- Failing FSharpx.Collections build: https://travis-ci.org/github/fsprojects/FSharpx.Collections/jobs/762568486