### PR TITLE
Seq extensions: add tryHeadTail

### DIFF
--- a/src/FSharpx.Collections/Collections.fs
+++ b/src/FSharpx.Collections/Collections.fs
@@ -61,6 +61,10 @@ module Seq =
         then None
         else Some(LanguagePrimitives.DivideByInt< (^a) > acc count)
 
+    let tryHeadTail<'T> (sequence: seq<'T>): Option<'T * seq<'T>> =
+        match Seq.tryHead sequence with
+        | None -> None
+        | Some head -> Some (head, Seq.tail sequence)
 
     /// Splits a sequences at the given index
     let splitAt n seq = (Seq.take n seq, Seq.skip n seq)

--- a/tests/FSharpx.Collections.Tests/SeqTests.fs
+++ b/tests/FSharpx.Collections.Tests/SeqTests.fs
@@ -52,6 +52,20 @@ module SeqTests =
                 data |> Seq.tryAverage
                 |> Expect.equal "tryAverage" (Some (5.5)) }
 
+            test "If I tryHeadTail and I don't have a head, I should return None" {
+                Seq.empty<float> |> Seq.tryHeadTail
+                |> Expect.isNone "tryHeadTail" }
+
+            test "If I tryHeadTail a non-empty seq, I should return both head and tail" {
+                let data = [1; 2; 3]
+                let actual = data |> Seq.tryHeadTail
+                Expect.isSome "tryHeadTail" actual
+                match actual with
+                | Some (head, tail) ->
+                    Expect.equal "tryHeadTail" 1 head
+                    Expect.sequenceEqual "tryHeadTail" [2; 3] tail
+                | _ -> failwith "Unreachable" }                
+
             test "I should be a to split a seq at an index" {
                 let (a,b) = Seq.splitAt 5 data
                 Expect.sequenceEqual "splitAt" (List.toSeq [1.;2.;3.;4.;5.]) a


### PR DESCRIPTION
FSharpLint's new recently added rule[1] complains about
function Seq.tail being a partial function, so we need
an alternative before all try-prefixed versions get
included in FSharp.Core[2]. This is not actually a
tryTail function but at least most uses of Seq.tail
use a Seq.head before it, so we can replace both calls
to Seq.(try)head & Seq.tail with a single-call to this
Seq.tryHeadTail which shouldn't be considered a partial
function anymore (even if it calls Seq.tail underneath).

Adding it in FSharpx.Collections would be a nice stopgap
instead of having to include this function in every F#
project that wants to enable this new FSharpLint rule.

[1] https://github.com/fsprojects/FSharpLint/pull/453
[2] https://github.com/fsharp/fslang-suggestions/issues/803