### PR TITLE
Adds PersistentVector.mapi

### DIFF
--- a/src/FSharpx.Collections/PersistentVector.fs
+++ b/src/FSharpx.Collections/PersistentVector.fs
@@ -470,6 +470,14 @@ module PersistentVector =
             ret <- ret.conj(f item)
         ret.persistent()
 
+    let mapi (f : int -> 'T -> 'T1) (vector: PersistentVector<'T>) : 'T1 PersistentVector =
+        let mutable ret = TransientVector()
+        let mutable index = 0
+        for item in vector do
+            ret <- ret.conj(f index item)
+            index <- index + 1
+        ret.persistent()
+
     let inline nth i (vector: PersistentVector<'T>) : 'T = vector.[i]
 
     let inline nthNth i j (vector: PersistentVector<PersistentVector<'T>>) : 'T = vector.[i] |> nth j

--- a/src/FSharpx.Collections/PersistentVector.fsi
+++ b/src/FSharpx.Collections/PersistentVector.fsi
@@ -103,6 +103,9 @@ module PersistentVector =
     /// O(n). Returns a vector whose elements are the results of applying the supplied function to each of the elements of a supplied vector.
     val map : ('T -> 'T1) -> PersistentVector<'T> -> PersistentVector<'T1>
 
+    /// O(n). Returns a vector whose elements are the results of applying the supplied function to each of the indices and elements of a supplied vector.
+    val mapi : (int -> 'T -> 'T1) -> PersistentVector<'T> -> PersistentVector<'T1>
+
     /// O(1) for all practical purposes; really O(log32n). Returns the value at the index. If the index is out of bounds it throws an exception.
     val inline nth : int -> PersistentVector<'T> -> 'T
 

--- a/tests/FSharpx.Collections.Tests/PersistentVectorTest.fs
+++ b/tests/FSharpx.Collections.Tests/PersistentVectorTest.fs
@@ -24,7 +24,7 @@ module PersistentVectorTests =
                 Expect.equal "cons" 4 (PersistentVector.empty |> PersistentVector.conj 1 |> PersistentVector.conj 4 |> PersistentVector.conj 25 |> PersistentVector.nth 1) }
 
             test "multiple assoc to the end should work like cons and create a vector" {
-                let v = PersistentVector.empty |> PersistentVector.update 0 1 |> PersistentVector.update 1 4 |> PersistentVector.update 2 25 
+                let v = PersistentVector.empty |> PersistentVector.update 0 1 |> PersistentVector.update 1 4 |> PersistentVector.update 2 25
                 Expect.equal "assoc" 1 (v |> PersistentVector.nth 0)
                 Expect.equal "assoc" 4 (v |> PersistentVector.nth 1)
                 Expect.equal "assoc" 25 (v |> PersistentVector.nth 2) }
@@ -38,7 +38,7 @@ module PersistentVectorTests =
                 Expect.equal "" 201 (!vector |> PersistentVector.nth 200) }
 
             test "assoc an element to a nonempty vector should not change the original vector" {
-                let v = PersistentVector.empty |> PersistentVector.conj "1" |> PersistentVector.conj "4" |> PersistentVector.conj "25" 
+                let v = PersistentVector.empty |> PersistentVector.conj "1" |> PersistentVector.conj "4" |> PersistentVector.conj "25"
 
                 Expect.equal "assoc" "5" (v |> PersistentVector.update 2 "5" |> PersistentVector.nth 2)
                 Expect.equal "assoc" "25" (v |> PersistentVector.nth 2) }
@@ -51,12 +51,12 @@ module PersistentVectorTests =
                 for i in 1..300 do
                     vector := PersistentVector.conj i (!vector)
 
-                let a = !vector |> Seq.toArray 
+                let a = !vector |> Seq.toArray
                 for i in 1..300 do i |> Expect.equal "toSeq toArray" a.[i-1] }
 
             test "vector can be created from a seq" {
-                let xs = [7;88;1;4;25;30] 
-                Expect.equal "" xs (PersistentVector.ofSeq xs |> Seq.toList) } 
+                let xs = [7;88;1;4;25;30]
+                Expect.equal "" xs (PersistentVector.ofSeq xs |> Seq.toList) }
 
             test "vector with 300 elements should allow assocN" {
                 let vector = ref PersistentVector.empty
@@ -66,7 +66,7 @@ module PersistentVectorTests =
                 for i in 1..300 do
                     vector := PersistentVector.update (i-1) (i*2) (!vector)
 
-                let a = !vector |> Seq.toArray 
+                let a = !vector |> Seq.toArray
                 for i in 1..300 do i * 2 |> Expect.equal "assocN" a.[i-1] }
 
             test "vector of vectors can be accessed with PersistentVector.nthNth" {
@@ -90,13 +90,13 @@ module PersistentVectorTests =
                 let outer = PersistentVector.empty |> PersistentVector.conj inner |> PersistentVector.conj inner
 
                 Expect.equal "" (Some 3) (outer |> PersistentVector.tryNthNth 0 2)
-                Expect.equal "" (Some 5) (outer |> PersistentVector.tryNthNth 1 4) } 
+                Expect.equal "" (Some 5) (outer |> PersistentVector.tryNthNth 1 4) }
 
             test "PersistentVector.tryNthNth returns None for out-of-bounds indices" {
                 let inner = [1; 2; 3; 4; 5] |> PersistentVector.ofSeq
                 let outer = PersistentVector.empty |> PersistentVector.conj inner |> PersistentVector.conj inner
 
-                Expect.isNone "PersistentVector.tryNthNth" (outer |> PersistentVector.tryNthNth 2 2)  
+                Expect.isNone "PersistentVector.tryNthNth" (outer |> PersistentVector.tryNthNth 2 2)
                 Expect.isNone "PersistentVector.tryNthNth" (outer |> PersistentVector.tryNthNth 1 5)
                 Expect.isNone "PersistentVector.tryNthNth" (outer |> PersistentVector.tryNthNth -1 2)
                 Expect.isNone "PersistentVector.tryNthNth" (outer |> PersistentVector.tryNthNth 1 -2) }
@@ -105,8 +105,8 @@ module PersistentVectorTests =
                 let inner = [1; 2; 3; 4; 5] |> PersistentVector.ofSeq
                 let outer = PersistentVector.empty |> PersistentVector.conj inner |> PersistentVector.conj inner
 
-                Expect.equal "PersistentVector.updateNth" 7 (outer |> PersistentVector.updateNth 0 2 7 |> PersistentVector.nthNth 0 2) 
-                Expect.equal "PersistentVector.updateNth" 9 (outer |> PersistentVector.updateNth 1 4 9 |> PersistentVector.nthNth 1 4) } 
+                Expect.equal "PersistentVector.updateNth" 7 (outer |> PersistentVector.updateNth 0 2 7 |> PersistentVector.nthNth 0 2)
+                Expect.equal "PersistentVector.updateNth" 9 (outer |> PersistentVector.updateNth 1 4 9 |> PersistentVector.nthNth 1 4) }
 
             test "PersistentVector.updateNth should not change the original vector" {
                 let inner = [1; 2; 3; 4; 5] |> PersistentVector.ofSeq
@@ -114,10 +114,10 @@ module PersistentVectorTests =
                 outer := PersistentVector.conj inner (!outer)
                 outer := PersistentVector.conj inner (!outer)
 
-                Expect.equal "PersistentVector.updateNth" 7 (!outer |> PersistentVector.updateNth 0 2 7 |> PersistentVector.nthNth 0 2) 
-                Expect.equal "PersistentVector.updateNth" 3 (!outer |> PersistentVector.nthNth 0 2) 
-                Expect.equal "PersistentVector.updateNth" 9 (!outer |> PersistentVector.updateNth 1 4 9 |> PersistentVector.nthNth 1 4) 
-                Expect.equal "PersistentVector.updateNth" 5 (!outer |> PersistentVector.nthNth 1 4) } 
+                Expect.equal "PersistentVector.updateNth" 7 (!outer |> PersistentVector.updateNth 0 2 7 |> PersistentVector.nthNth 0 2)
+                Expect.equal "PersistentVector.updateNth" 3 (!outer |> PersistentVector.nthNth 0 2)
+                Expect.equal "PersistentVector.updateNth" 9 (!outer |> PersistentVector.updateNth 1 4 9 |> PersistentVector.nthNth 1 4)
+                Expect.equal "PersistentVector.updateNth" 5 (!outer |> PersistentVector.nthNth 1 4) }
 
             test "PersistentVector.updateNth throws exception for out-of-bounds indices" {
                 let inner = [1; 2; 3; 4; 5] |> PersistentVector.ofSeq
@@ -135,7 +135,7 @@ module PersistentVectorTests =
                 Expect.isNone "" (PersistentVector.tryUpdateNth 0 6 7 outer)
                 Expect.isNone "" (PersistentVector.tryUpdateNth 9 2 7 outer)
                 Expect.isNone "" (PersistentVector.tryUpdateNth 1 -4 7 outer)
-                Expect.isNone "" (PersistentVector.tryUpdateNth -1 4 7 outer) } 
+                Expect.isNone "" (PersistentVector.tryUpdateNth -1 4 7 outer) }
 
             test "PersistentVector.tryUpdateNth is like PersistentVector.updateNth but returns option" {
                 let inner = [1; 2; 3; 4; 5] |> PersistentVector.ofSeq
@@ -156,23 +156,23 @@ module PersistentVectorTests =
                 outer := PersistentVector.conj inner (!outer)
 
                 Expect.equal "PersistentVector.tryUpdateNth" 7 (!outer |> PersistentVector.tryUpdateNth 0 2 7 |> Option.get |> PersistentVector.nthNth 0 2)
-                Expect.equal "PersistentVector.tryUpdateNth" 3 (!outer |> PersistentVector.nthNth 0 2) 
-                Expect.equal "PersistentVector.tryUpdateNth" 9 (!outer |> PersistentVector.tryUpdateNth 1 4 9 |> Option.get |> PersistentVector.nthNth 1 4) 
-                Expect.equal "PersistentVector.tryUpdateNth" 5 (!outer |> PersistentVector.nthNth 1 4) } 
+                Expect.equal "PersistentVector.tryUpdateNth" 3 (!outer |> PersistentVector.nthNth 0 2)
+                Expect.equal "PersistentVector.tryUpdateNth" 9 (!outer |> PersistentVector.tryUpdateNth 1 4 9 |> Option.get |> PersistentVector.nthNth 1 4)
+                Expect.equal "PersistentVector.tryUpdateNth" 5 (!outer |> PersistentVector.nthNth 1 4) }
 
             test "can peek elements from a vector" {
-                let vector = PersistentVector.empty |> PersistentVector.conj 1 |> PersistentVector.conj 4 |> PersistentVector.conj 25 
+                let vector = PersistentVector.empty |> PersistentVector.conj 1 |> PersistentVector.conj 4 |> PersistentVector.conj 25
                 Expect.equal "last" 25 (vector |> PersistentVector.last) }
 
             test "can pop elements from a vector" {
-                let vector = PersistentVector.empty |> PersistentVector.conj 1 |> PersistentVector.conj 4 |> PersistentVector.conj 25 
-                Expect.equal "last" 25 (vector |> PersistentVector.last) 
-                Expect.equal "last" 4 (vector |> PersistentVector.initial |> PersistentVector.last) 
-                Expect.equal "last" 1 (vector |> PersistentVector.initial |> PersistentVector.initial |> PersistentVector.last) 
+                let vector = PersistentVector.empty |> PersistentVector.conj 1 |> PersistentVector.conj 4 |> PersistentVector.conj 25
+                Expect.equal "last" 25 (vector |> PersistentVector.last)
+                Expect.equal "last" 4 (vector |> PersistentVector.initial |> PersistentVector.last)
+                Expect.equal "last" 1 (vector |> PersistentVector.initial |> PersistentVector.initial |> PersistentVector.last)
 
-                Expect.equal "last" 3 (vector |> PersistentVector.length) 
-                Expect.equal "last" 2 (vector |> PersistentVector.initial |> PersistentVector.length) 
-                Expect.equal "last" 1 (vector |> PersistentVector.initial |> PersistentVector.initial |> PersistentVector.length) } 
+                Expect.equal "last" 3 (vector |> PersistentVector.length)
+                Expect.equal "last" 2 (vector |> PersistentVector.initial |> PersistentVector.length)
+                Expect.equal "last" 1 (vector |> PersistentVector.initial |> PersistentVector.initial |> PersistentVector.length) }
 
             test "vector with 300 elements should allow pop" {
                 let vector = ref PersistentVector.empty
@@ -213,7 +213,7 @@ module PersistentVectorTests =
                 for i in 1..3 do
                     vector3 := PersistentVector.conj (2*i) (!vector3)
 
-                Expect.equal "compare" vector1 vector1 
+                Expect.equal "compare" vector1 vector1
                 Expect.equal "compare" vector1 vector2
                 Expect.notEqual "compare" vector1 vector3 }
 
@@ -235,11 +235,21 @@ module PersistentVectorTests =
 
                 let vector2 = PersistentVector.map (fun x -> x * 2) (!vector)
 
-                let a = vector2 |> Seq.toArray 
+                let a = vector2 |> Seq.toArray
                 for i in 1..300 do i * 2 |> Expect.equal "map" a.[i-1] }
 
+            test "vector should allow mapi" {
+                let vector = ref PersistentVector.empty
+                for i in 1..300 do
+                    vector := PersistentVector.conj i (!vector)
+
+                let vector2 = PersistentVector.mapi (fun index x -> index + x * 2) (!vector)
+
+                let a = vector2 |> Seq.toArray
+                for i in 1..300 do (i - 1) + i * 2 |> Expect.equal "map" a.[i-1] }
+
             test "vector should allow init" {
-                let vector = PersistentVector.init 5 (fun x -> x * 2) 
+                let vector = PersistentVector.init 5 (fun x -> x * 2)
                 let s = Seq.init 5 (fun x -> x * 2)
 
                 Expect.equal "init" [0;2;4;6;8] (s |> Seq.toList)
@@ -250,7 +260,7 @@ module PersistentVectorTests =
                 let fullVec = PersistentVector.ofSeq seq30
                 for i in 1..35 do
                     let vecs = PersistentVector.windowSeq i seq30
-                    Expect.equal "windowSeq" fullVec (vecs |> PersistentVector.fold PersistentVector.append PersistentVector.empty) } 
+                    Expect.equal "windowSeq" fullVec (vecs |> PersistentVector.fold PersistentVector.append PersistentVector.empty) }
 
             test "windowSeq should return vectors of equal length if possible" {
                 let seq30 = seq { for i in 1..30 do yield i }
@@ -259,12 +269,12 @@ module PersistentVectorTests =
                 let len5vecs = PersistentVector.windowSeq 5 seq30
                 let len6vecs = PersistentVector.windowSeq 6 seq30
 
-                Expect.equal "windowSeq" 10 (len3vecs |> PersistentVector.length) 
+                Expect.equal "windowSeq" 10 (len3vecs |> PersistentVector.length)
                 Expect.equal "windowSeq" 6 (len5vecs |> PersistentVector.length)
                 Expect.equal "windowSeq" 5 (len6vecs |> PersistentVector.length)
-                Expect.equal "windowSeq" [3;3;3;3;3;3;3;3;3;3] (len3vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList) 
+                Expect.equal "windowSeq" [3;3;3;3;3;3;3;3;3;3] (len3vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList)
                 Expect.equal "windowSeq" [5;5;5;5;5;5] (len5vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList)
-                Expect.equal "windowSeq" [6;6;6;6;6] (len6vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList) } 
+                Expect.equal "windowSeq" [6;6;6;6;6] (len6vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList) }
 
             test "windowSeq should return vectors all of equal length except the last" {
                 let seq30 = seq { for i in 1..30 do yield i }
@@ -274,14 +284,14 @@ module PersistentVectorTests =
                 let len8vecs = PersistentVector.windowSeq 8 seq30
                 let len17vecs = PersistentVector.windowSeq 17 seq30
 
-                Expect.equal "windowSeq" 8 (len4vecs |> PersistentVector.length) 
-                Expect.equal "windowSeq" 5 (len7vecs |> PersistentVector.length) 
-                Expect.equal "windowSeq" 4 (len8vecs |> PersistentVector.length) 
-                Expect.equal "windowSeq" 2 (len17vecs |> PersistentVector.length) 
+                Expect.equal "windowSeq" 8 (len4vecs |> PersistentVector.length)
+                Expect.equal "windowSeq" 5 (len7vecs |> PersistentVector.length)
+                Expect.equal "windowSeq" 4 (len8vecs |> PersistentVector.length)
+                Expect.equal "windowSeq" 2 (len17vecs |> PersistentVector.length)
                 Expect.equal "windowSeq" [4;4;4;4;4;4;4;2] (len4vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList)
-                Expect.equal "windowSeq" [7;7;7;7;2] (len7vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList) 
-                Expect.equal "windowSeq" [8;8;8;6] (len8vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList) 
-                Expect.equal "windowSeq" [17;13] (len17vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList) } 
+                Expect.equal "windowSeq" [7;7;7;7;2] (len7vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList)
+                Expect.equal "windowSeq" [8;8;8;6] (len8vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList)
+                Expect.equal "windowSeq" [17;13] (len17vecs |> PersistentVector.map PersistentVector.length |> PersistentVector.toSeq |> Seq.toList) }
 
             testList "rangedIterator" [
                 test "0..count is same as toSeq" {


### PR DESCRIPTION
This mirrors `List.mapi` and `Seq.mapi` in the core library. 