### PR TITLE
Fix ByteString.empty comparison problem

### DIFF
--- a/src/FSharpx.Collections/ByteString.fs
+++ b/src/FSharpx.Collections/ByteString.fs
@@ -124,7 +124,7 @@ module ByteString =
         x.Array, x.Offset, x.Count
 
     /// needs .fsi file
-    let empty = ByteString()
+    let empty = ByteString([||])
 
     /// needs .fsi file
     let singleton c =

--- a/tests/FSharpx.Collections.Tests/ByteStringTest.fs
+++ b/tests/FSharpx.Collections.Tests/ByteStringTest.fs
@@ -13,6 +13,9 @@ module ByteStringTests =
         "empty1", ByteString.create ""B, ByteString.create ""B, 0
         "empty2", ByteString.create ""B, ByteString.create "a"B, -1
         "empty3", ByteString.create "a"B, ByteString.create ""B, 1
+        "empty5", ByteString.empty, ByteString.create "a"B, -1
+        "empty6", ByteString.create "a"B, ByteString.empty, 1
+        "empty7", ByteString.empty, ByteString.create ""B, 0
 
         "same1", ByteString.create "a"B, ByteString.create "a"B, 0
         "smaller1", ByteString.create "a"B, ByteString.create "b"B, -1


### PR DESCRIPTION
While working on reenabling ignored property tests for monoids based on `ByteString` defined in `FSharpx.Extras` I stumbled upon this bug, `ByteString` being marked as struct results in it getting a "free" parameterless constructor that creates it with `(null, 0, 0`) (defaults for `byte[]` and `int`). This constructor is later used to implement `ByteString.empty`. The problem is that it does not play well with comparison and equality (it is based on comparison).

I added test cases that illustrate the issue. Solution finding in progress.