### PR TITLE
Fix RunTests fake target

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,9 +26,11 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: ${{ matrix.dotnet }}
+        dotnet-version: |
+          5.0.x
+          ${{ matrix.dotnet }}
     - name: Install local tools
       run: dotnet tool restore
     - name: Paket Restore

--- a/FSharpx.Collections.sln
+++ b/FSharpx.Collections.sln
@@ -27,12 +27,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{E8AA1C
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{DF958161-9599-469B-984A-531F0EBB2FD9}"
 	ProjectSection(SolutionItems) = preProject
-		.travis.yml = .travis.yml
-		appveyor.yml = appveyor.yml
 		build.fsx = build.fsx
-		build.proj = build.proj
-		fake.cmd = fake.cmd
-		fake.sh = fake.sh
+		build.cmd = build.cmd
+		build.sh = build.sh
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{F0FAE041-7EC2-4ECC-8FA3-DC8B87310757}"

--- a/build.fsx
+++ b/build.fsx
@@ -104,7 +104,7 @@ Target.create "Build" (fun _ ->
 // Run the unit tests using test runner
 
 Target.create "RunTests" (fun _ ->
-    !! "tests/**/bin/Release/net6.0/*Tests.dll"
+    !! "tests/**/bin/Release/net5.0/*Tests.dll"
     |> Expecto.run (fun x -> 
         { x with 
             Parallel = true


### PR DESCRIPTION
Path in RunTests used net6 while the test projects compile to net5. As a result, no tests were executed. I propose we bump the tests to net6 due to net5 being eovs, but in a different PR after making what we have work.