### PR TITLE
Remove Seq.tryHead

### DIFF
--- a/src/FSharpx.Collections/Collections.fs
+++ b/src/FSharpx.Collections/Collections.fs
@@ -166,11 +166,6 @@ module Seq =
 
         next()
 
-    /// A safe version of seq head
-    let tryHead(source: seq<_>) =
-        use e = source.GetEnumerator()
-        if e.MoveNext() then Some(e.Current) else None //empty list
-
     let tail(source: seq<_>) = seq {
         use e = source.GetEnumerator()
 


### PR DESCRIPTION
Because it is already included in FSharp.Core:
https://fsharp.github.io/fsharp-core-docs/reference/fsharp-collections-seqmodule.html#tryHead