### PR TITLE
Add docs for tryHeadTail

### DIFF
--- a/src/FSharpx.Collections/Collections.fs
+++ b/src/FSharpx.Collections/Collections.fs
@@ -69,6 +69,7 @@ module Seq =
         else
             Some(LanguagePrimitives.DivideByInt<( ^a)> acc count)
 
+    /// The same as Seq.tryHead but also returning the tail alongside the head (in a tuple)
     let tryHeadTail<'T>(sequence: seq<'T>) : Option<'T * seq<'T>> =
         match Seq.tryHead sequence with
         | None -> None


### PR DESCRIPTION
It was not showing up in the API reference page
of FSharpx.Collections, so hopefully with this, it will appear.