### PR TITLE
Update GitHub Actions workflow for NuGet publishing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  id-token: write
+
 jobs:
   build:
 
@@ -43,29 +46,15 @@ jobs:
     - name: Build and Test
       run: dotnet run --project build/build.fsproj
 
-    - name: Check secrets presence
-      id: checksecrets
-      shell: bash
-      run: |
-        echo "secretspresent=YES" >> $GITHUB_OUTPUT
-        if [ "$GITHUB_TOKEN" == "" ]; then
-          echo "secretspresent=NO" >> $GITHUB_OUTPUT
-        fi
-        if [ "$NUGET_KEY" == "" ]; then
-          echo "secretspresent=NO" >> $GITHUB_OUTPUT
-        fi
-      env:
-        NUGET_KEY: ${{ secrets.NUGETKEY }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Publish prerelease NuGet to GitHub
-      if: (steps.checksecrets.outputs.secretspresent != 'NO') && matrix.os == 'windows-latest' && github.ref == 'refs/heads/master' && github.event.inputs.release != 'true'
-      run: dotnet run --project build/build.fsproj -- PublishCINuGet
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Obtain NuGet key
+      # this hash is v1.1.0
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544
+      id: login
+      with:
+          user: dsyme
     - name: Publish NuGet to NuGet.org
-      if: (steps.checksecrets.outputs.secretspresent != 'NO') && matrix.os == 'windows-latest' && github.ref == 'refs/heads/master' && github.event.inputs.release == 'true'
+      if: matrix.os == 'windows-latest' && github.ref == 'refs/heads/master' && github.event.inputs.release == 'true'
       run: dotnet run --project build/build.fsproj -- Release
       env:
-        NUGET_KEY: ${{ secrets.NUGETKEY }}
+        NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 


### PR DESCRIPTION
@gdziadkiewicz This will use nuget trusted publishing, which means no tokens via  trust relationship I'll ad to nuget.org

It removes github publishing which I think is the right choice to keep things simple and key-free